### PR TITLE
v0.4.0 — audit refactor, shared tool defs, MCP prompts, honest play fallback

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -15,6 +15,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Verify tag matches package.json version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          PKG=$(jq -r .version package.json)
+          if [ "$VERSION" != "$PKG" ]; then
+            echo "::error::Git tag v$VERSION does not match package.json version $PKG. Bump package.json before tagging."
+            exit 1
+          fi
+          echo "Version check OK: $VERSION"
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ dist/
 CLAUDE.md
 .claude/
 
+# Local-only internal docs (audit reports, working notes) — not for the public repo
+docs/internal/
+
 # wrangler files
 .wrangler
 .dev.vars*

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ On Windows, `npx` is a `.cmd` file and requires a shell wrapper:
 <details>
 <summary>Render modes (for non-ext-apps clients)</summary>
 
-The server auto-detects ext-apps support. For clients that don't support it (Cherry Studio, CLI environments), use `--render-mode`:
+Clients that support ext-apps render the interactive UI inline automatically (`auto` mode). For clients that don't (Cherry Studio, CLI environments), use `--render-mode`:
 
 | Mode | Behavior |
 |------|----------|
@@ -196,6 +196,16 @@ The server auto-detects ext-apps support. For clients that don't support it (Che
 | `get-music-guide` | ABC reference (7 topics: instruments, drums, syntax, genres...) |
 | `get-strudel-guide` | Strudel reference (7 topics: sounds, effects, patterns, genres...) |
 | `search-music-docs` | Semantic search over strudel.cc and ABCJS docs |
+
+## Prompts
+
+Slash-command / menu entry points, in clients that surface MCP prompts:
+
+| Prompt | What it does |
+|--------|--------------|
+| `compose-beat` | Generate + play a Strudel pattern in a genre (args: `genre`, `mood?`) |
+| `harmonize-melody` | Add chords/accompaniment to an ABC melody and play it (args: `melody`, `style?`) |
+| `arrange-tune` | Turn a melody/idea into a multi-voice arrangement (args: `tune`, `instrumentation?`) |
 
 ## Development
 

--- a/mcp-app.html
+++ b/mcp-app.html
@@ -16,12 +16,16 @@
         <div id="style-selector" class="toolbar-group"></div>
         <div id="instrument-selector" class="toolbar-group"></div>
       </div>
-      <span id="status" class="status">Waiting for notation...</span>
+      <span id="status" class="status" role="status" aria-live="polite">Loading score…</span>
     </header>
 
     <section class="sheet-section">
       <div id="sheet-music" class="sheet-music-container">
         <!-- ABC notation will be rendered here by abcjs -->
+        <div class="loading-skeleton" role="status" aria-live="polite">
+          <span class="spinner" aria-hidden="true"></span>
+          <span>Loading score…</span>
+        </div>
       </div>
     </section>
   </main>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-music-studio",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "description": "Two-mode MCP music studio: scored composition (ABC notation) and live performance (Strudel). Interactive ext-apps UI with sheet music rendering, 30+ instruments, style presets, and live coding REPL.",
   "keywords": [
@@ -33,7 +33,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc --noEmit && cross-env INPUT=mcp-app.html vite build && cross-env INPUT=strudel-app.html vite build && tsc -p tsconfig.server.json && bun build server.ts --outdir dist --target node && bun build main.ts --outfile dist/index.js --target node --external \"./server.js\" --banner \"#!/usr/bin/env node\"",
+    "build": "bun scripts/sync-version.mjs && tsc --noEmit && cross-env INPUT=mcp-app.html vite build && cross-env INPUT=strudel-app.html vite build && tsc -p tsconfig.server.json && bun build server.ts --outdir dist --target node && bun build main.ts --outfile dist/index.js --target node --external \"./server.js\" --banner \"#!/usr/bin/env node\"",
     "test": "bunx vitest run",
     "test:watch": "bunx vitest",
     "watch": "cross-env INPUT=mcp-app.html vite build --watch",

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -1,0 +1,13 @@
+// Generates src/version.ts from package.json so the version lives in ONE place.
+// Run automatically at the start of `bun run build`.
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
+const body =
+  "// AUTO-GENERATED from package.json by scripts/sync-version.mjs — do not edit by hand.\n" +
+  `export const VERSION = ${JSON.stringify(pkg.version)};\n`;
+writeFileSync(join(root, "src", "version.ts"), body);
+console.error(`[sync-version] src/version.ts → ${pkg.version}`);

--- a/server.json
+++ b/server.json
@@ -8,7 +8,7 @@
     "source": "github",
     "id": "1185354744"
   },
-  "version": "0.3.0",
+  "version": "0.4.0",
   "icons": [
     {
       "src": "https://raw.githubusercontent.com/linxule/mcp-music-studio/main/assets/logo.png",
@@ -19,10 +19,16 @@
     {
       "registryType": "npm",
       "identifier": "mcp-music-studio",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "transport": {
         "type": "stdio"
       }
+    }
+  ],
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp-music-studio.linxule.workers.dev/mcp"
     }
   ]
 }

--- a/server.ts
+++ b/server.ts
@@ -5,14 +5,13 @@ import type {
 } from "@modelcontextprotocol/sdk/types.js";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { randomUUID } from "node:crypto";
 import { z } from "zod";
 import {
   RESOURCE_MIME_TYPE,
   registerAppResource,
   registerAppTool,
-  getUiCapability,
 } from "@modelcontextprotocol/ext-apps/server";
-import { STYLE_NAMES } from "./src/music-logic.js";
 import {
   createPlaySheetMusicResult,
   type ParseOnlyFn,
@@ -26,58 +25,69 @@ import {
   STRUDEL_GUIDES,
   type StrudelGuideTopic,
 } from "./src/strudel-guide.js";
-import {
-  ABC_GUIDE_TOPICS,
-  ABC_GUIDES,
-  DEFAULT_ABC_NOTATION,
-} from "./src/abc-guide.js";
+import { ABC_GUIDE_TOPICS, ABC_GUIDES } from "./src/abc-guide.js";
 import {
   generateStrudelPlayerHtml,
   openStrudelInBrowser,
 } from "./src/strudel-browser-fallback.js";
+import { VERSION } from "./src/version.js";
+import {
+  SHEET_RESOURCE_URI,
+  STRUDEL_RESOURCE_URI,
+  SERVER_INSTRUCTIONS,
+  advertiseUiExtension,
+  PLAY_TOOL_ANNOTATIONS,
+  GUIDE_TOOL_ANNOTATIONS,
+  SEARCH_TOOL_ANNOTATIONS,
+  SHEET_CSP,
+  STRUDEL_CSP,
+  PLAY_SHEET_BASE_DESCRIPTION,
+  PLAY_SHEET_EXT_APPS_SUFFIX,
+  PLAY_SHEET_FALLBACK_SUFFIX,
+  playSheetInputSchema,
+  PLAY_LIVE_BASE_DESCRIPTION,
+  PLAY_LIVE_EXT_APPS_SUFFIX,
+  PLAY_LIVE_FALLBACK_SUFFIX,
+  playLiveInputSchema,
+  buildPlayLiveResult,
+  GET_MUSIC_GUIDE_DESCRIPTION,
+  GET_MUSIC_GUIDE_TOPIC_DESCRIPTION,
+  GET_STRUDEL_GUIDE_DESCRIPTION,
+  GET_STRUDEL_GUIDE_TOPIC_DESCRIPTION,
+  SEARCH_DOCS_DESCRIPTION,
+  searchDocsInputSchema,
+  searchMusicDocs,
+  registerMusicPrompts,
+} from "./src/shared/tool-defs.js";
 
 const DIST_DIR = import.meta.filename.endsWith(".ts")
   ? path.join(import.meta.dirname, "dist")
   : import.meta.dirname;
 
-const GUIDE_TOPICS = ABC_GUIDE_TOPICS;
-const GUIDES = ABC_GUIDES;
-
 // =============================================================================
-// Server
+// Exported handlers (also used by the test suite)
 // =============================================================================
 
-export async function handlePlaySheetMusic({
-  abcNotation,
-}: {
-  abcNotation: string;
-}, parseOnly?: ParseOnlyFn): Promise<CallToolResult> {
+export async function handlePlaySheetMusic(
+  { abcNotation }: { abcNotation: string },
+  parseOnly?: ParseOnlyFn,
+): Promise<CallToolResult> {
   return createPlaySheetMusicResult(abcNotation, parseOnly);
 }
 
 export async function handleGetMusicGuide({
   topic,
 }: {
-  topic: (typeof GUIDE_TOPICS)[number];
+  topic: (typeof ABC_GUIDE_TOPICS)[number];
 }): Promise<CallToolResult> {
-  return {
-    content: [{ type: "text", text: GUIDES[topic] }],
-  };
+  return { content: [{ type: "text", text: ABC_GUIDES[topic] }] };
 }
 
 export async function handlePlayLivePattern(args: {
   code: string;
   title?: string;
 }): Promise<CallToolResult> {
-  const label = args.title ? `"${args.title}" — ` : "";
-  return {
-    content: [
-      {
-        type: "text",
-        text: `${label}Strudel pattern playing.`,
-      },
-    ],
-  };
+  return buildPlayLiveResult(args);
 }
 
 export async function handleGetStrudelGuide({
@@ -85,9 +95,7 @@ export async function handleGetStrudelGuide({
 }: {
   topic: StrudelGuideTopic;
 }): Promise<CallToolResult> {
-  return {
-    content: [{ type: "text", text: STRUDEL_GUIDES[topic] }],
-  };
+  return { content: [{ type: "text", text: STRUDEL_GUIDES[topic] }] };
 }
 
 export type RenderMode = "auto" | "html" | "browser";
@@ -97,92 +105,44 @@ export interface ServerOptions {
   outputDir?: string;
 }
 
+// =============================================================================
+// Server
+// =============================================================================
+
 export function createServer(options?: ServerOptions): McpServer {
   const defaultRenderMode = options?.defaultRenderMode ?? "auto";
   const outputDir = options?.outputDir;
-  let clientSupportsExtApps = false;
 
-  const server = new McpServer({
-    name: "Music Studio",
-    version: "0.3.0",
-  });
+  const server = new McpServer(
+    { name: "Music Studio", version: VERSION },
+    { instructions: SERVER_INSTRUCTIONS },
+  );
 
-  const resourceUri = "ui://sheet-music/mcp-app.html";
+  // Advertise ext-apps UI support symmetrically with the remote worker so clients
+  // (and registry validators) see the same capability set on both transports.
+  advertiseUiExtension(server.server);
+
+  // Slash-command prompts: compose-beat, harmonize-melody, arrange-tune.
+  registerMusicPrompts(server);
+
+  // Description is chosen once, deterministically, by the configured render mode.
+  // In "auto" (default) the player renders inline for ext-apps clients; "html"/
+  // "browser" are set explicitly for non-ext-apps clients. This replaces the old
+  // oninitialized re-registration, which threw "already registered" (swallowed)
+  // and could never fire before tools/list in stateless HTTP anyway.
+  const inlineMode = defaultRenderMode === "auto";
 
   // ---------------------------------------------------------------------------
-  // Shared schema + handler for play-sheet-music (description adapts to client)
+  // Tool: play-sheet-music
   // ---------------------------------------------------------------------------
-  const playInputSchema = z.object({
-    abcNotation: z
-      .string()
-      .default(DEFAULT_ABC_NOTATION)
-      .describe(
-        "ABC notation string. Include chord symbols (\"C\", \"Am7\") above notes for auto-accompaniment with style presets.",
-      ),
-    title: z
-      .string()
-      .optional()
-      .describe("Piece title (overrides T: in ABC). Displayed in the widget header."),
-    instrument: z
-      .string()
-      .optional()
-      .describe(
-        "Default instrument (e.g. 'Flute', 'Cello', 'Acoustic Grand Piano', 'Alto Sax'). " +
-        "Use get-music-guide with topic 'instruments' for the full list.",
-      ),
-    style: z
-      .enum(STYLE_NAMES)
-      .optional()
-      .describe(
-        "Accompaniment style. Adds drums, bass, and chord patterns automatically. " +
-        "Your ABC needs chord symbols (\"C\", \"Am\") for accompaniment to work. " +
-        "Options: rock, jazz, bossa, waltz, march, reggae, folk, classical.",
-      ),
-    tempo: z
-      .number()
-      .min(40)
-      .max(240)
-      .optional()
-      .describe("Tempo in BPM (40-240). Overrides Q: in ABC notation."),
-    swing: z
-      .number()
-      .min(0)
-      .max(100)
-      .optional()
-      .describe(
-        "Swing percentage (0-100). 0=straight, 33=light swing, 66=heavy swing. Great for jazz and blues.",
-      ),
-    transpose: z
-      .number()
-      .min(-12)
-      .max(12)
-      .optional()
-      .describe(
-        "Transpose by semitones (-12 to 12). Positive=higher, negative=lower.",
-      ),
-  });
-
-  const BASE_DESCRIPTION =
-    "Compose and play sheet music with visual notation, multi-instrument audio, " +
-    "and style presets. Write ABC notation for melodies, arrangements, harmonized " +
-    "pieces, or well-known tunes. Add a style (rock, jazz, bossa, waltz, folk...) " +
-    "for automatic drums, bass, and chord accompaniment. " +
-    "Use get-music-guide for genre templates, instrument lists, and ABC syntax reference.";
-
-  const EXT_APPS_SUFFIX =
-    "\n\nThe music player renders inline with interactive playback controls.";
-
-  const FALLBACK_SUFFIX =
-    "\n\nThe music player is delivered as HTML or opened in the browser automatically.";
-
   const playHandler = async (
-    args: z.infer<typeof playInputSchema>,
+    args: z.infer<typeof playSheetInputSchema>,
   ): Promise<CallToolResult> => {
     const result = await handlePlaySheetMusic(args);
 
     if (result.isError) return result;
 
-    // Explicit --render-mode flag always wins; auto-detect only affects description
+    // Explicit --render-mode flag delivers HTML / opens a browser file.
     if (defaultRenderMode === "auto") return result;
 
     const playerOpts = {
@@ -204,7 +164,7 @@ export function createServer(options?: ServerOptions): McpServer {
           {
             type: "resource" as const,
             resource: {
-              uri: `music://player/${Date.now()}.html`,
+              uri: `music://player/${randomUUID()}.html`,
               mimeType: "text/html",
               text: html,
             },
@@ -225,7 +185,7 @@ export function createServer(options?: ServerOptions): McpServer {
         result.content = [
           {
             type: "text",
-            text: `${text}\n\nMusic player saved and opening in browser.\nFile: ${fileUrl}`,
+            text: `${text}\n\nMusic player saved to: ${fileUrl}\n(Attempting to open it in your browser.)`,
           },
         ];
       } catch (err) {
@@ -239,42 +199,20 @@ export function createServer(options?: ServerOptions): McpServer {
     return result;
   };
 
-  // Register tool statically (works in HTTP stateless mode where each request
-  // is a new server instance and oninitialized may not fire before tools/list).
-  // Uses fallback description by default; upgraded to ext-apps in oninitialized.
   registerAppTool(
     server,
     "play-sheet-music",
     {
       title: "Play Sheet Music",
-      description: BASE_DESCRIPTION + FALLBACK_SUFFIX,
-      inputSchema: playInputSchema,
-      _meta: { ui: { resourceUri } },
+      description:
+        PLAY_SHEET_BASE_DESCRIPTION +
+        (inlineMode ? PLAY_SHEET_EXT_APPS_SUFFIX : PLAY_SHEET_FALLBACK_SUFFIX),
+      inputSchema: playSheetInputSchema,
+      annotations: PLAY_TOOL_ANNOTATIONS,
+      _meta: { ui: { resourceUri: SHEET_RESOURCE_URI } },
     },
     playHandler,
   );
-
-  // Detect ext-apps capability and upgrade tool description for capable clients
-  server.server.oninitialized = () => {
-    const caps = server.server.getClientCapabilities();
-    const uiCap = getUiCapability(caps);
-    clientSupportsExtApps = !!uiCap?.mimeTypes?.includes(RESOURCE_MIME_TYPE);
-
-    if (clientSupportsExtApps) {
-      // Re-register with ext-apps-specific description
-      registerAppTool(
-        server,
-        "play-sheet-music",
-        {
-          title: "Play Sheet Music",
-          description: BASE_DESCRIPTION + EXT_APPS_SUFFIX,
-          inputSchema: playInputSchema,
-          _meta: { ui: { resourceUri } },
-        },
-        playHandler,
-      );
-    }
-  };
 
   // ---------------------------------------------------------------------------
   // Tool: get-music-guide
@@ -283,34 +221,28 @@ export function createServer(options?: ServerOptions): McpServer {
     "get-music-guide",
     {
       title: "Music Reference Guide",
-      description:
-        "Returns detailed reference material for music composition. " +
-        "Topics: instruments (GM instrument list + combos), drums (patterns + percussion notes), " +
-        "abc-syntax (notation reference), arrangements (multi-voice patterns), " +
-        "genres (complete ABC templates for jazz/blues/folk/rock/bossa/classical), " +
-        "styles (what each style preset does), midi-directives (%%MIDI reference).",
+      description: GET_MUSIC_GUIDE_DESCRIPTION,
       inputSchema: z.object({
         topic: z
-          .enum(GUIDE_TOPICS)
-          .describe(
-            "Reference topic. Start with 'genres' for complete examples, 'styles' to understand presets, or 'instruments' for the full instrument list.",
-          ),
+          .enum(ABC_GUIDE_TOPICS)
+          .describe(GET_MUSIC_GUIDE_TOPIC_DESCRIPTION),
       }),
+      annotations: GUIDE_TOOL_ANNOTATIONS,
     },
     handleGetMusicGuide,
   );
 
   // ---------------------------------------------------------------------------
-  // Resources: music://guide/* (mirrors get-music-guide for resource-capable clients)
+  // Resources: music://guide/* (mirrors get-music-guide)
   // ---------------------------------------------------------------------------
-  for (const topic of GUIDE_TOPICS) {
+  for (const topic of ABC_GUIDE_TOPICS) {
     const uri = `music://guide/${topic}`;
     server.registerResource(
       `Music Guide: ${topic}`,
       uri,
       { mimeType: "text/plain", description: `Music reference: ${topic}` },
       async (): Promise<ReadResourceResult> => ({
-        contents: [{ uri, mimeType: "text/plain", text: GUIDES[topic] }],
+        contents: [{ uri, mimeType: "text/plain", text: ABC_GUIDES[topic] }],
       }),
     );
   }
@@ -320,28 +252,21 @@ export function createServer(options?: ServerOptions): McpServer {
   // ---------------------------------------------------------------------------
   registerAppResource(
     server,
-    resourceUri,
-    resourceUri,
+    SHEET_RESOURCE_URI,
+    SHEET_RESOURCE_URI,
     { mimeType: RESOURCE_MIME_TYPE, description: "Sheet Music Viewer UI" },
     async (): Promise<ReadResourceResult> => {
       const html = await fs.readFile(
         path.join(DIST_DIR, "mcp-app.html"),
         "utf-8",
       );
-
       return {
         contents: [
           {
-            uri: resourceUri,
+            uri: SHEET_RESOURCE_URI,
             mimeType: RESOURCE_MIME_TYPE,
             text: html,
-            _meta: {
-              ui: {
-                csp: {
-                  connectDomains: ["https://paulrosen.github.io"],
-                },
-              },
-            },
+            _meta: { ui: { csp: { ...SHEET_CSP } } },
           },
         ],
       };
@@ -351,50 +276,8 @@ export function createServer(options?: ServerOptions): McpServer {
   // ===========================================================================
   // STRUDEL — Live Pattern Tool
   // ===========================================================================
-
-  const strudelResourceUri = "ui://strudel/strudel-app.html";
-
-  const strudelInputSchema = z.object({
-    code: z
-      .string()
-      .describe(
-        "Strudel pattern code. Uses TidalCycles mini-notation in JavaScript. " +
-        "Use stack() to layer drums, bass, and melody. " +
-        "Set tempo with setcps(bpm/60/4) or use the bpm parameter.",
-      ),
-    title: z
-      .string()
-      .optional()
-      .describe("Pattern title displayed in the widget header (e.g. 'Midnight Rain')."),
-    bpm: z
-      .number()
-      .min(40)
-      .max(300)
-      .optional()
-      .describe("Tempo in BPM (40-300). Converts to setcps() automatically."),
-    autoplay: z
-      .boolean()
-      .optional()
-      .describe("Start playing immediately (default: true). May require user click due to browser autoplay policy."),
-  });
-
-  const STRUDEL_BASE_DESCRIPTION =
-    "Live-code music patterns using TidalCycles mini-notation in JavaScript. " +
-    "Layer drums, synths, and bass with stack(). Choose from 72 drum machine banks, " +
-    "128 GM instruments, built-in synths, and a full effects chain. " +
-    "Patterns play in a REPL the user can edit directly. " +
-    "Use get-strudel-guide for genre templates, sound references, and advanced features " +
-    "like visualization, arrangement, and sample loading.";
-
-  const STRUDEL_EXT_APPS_SUFFIX =
-    "\n\nThe Strudel REPL renders inline with an editable code editor, " +
-    "visualizations, and playback controls.";
-
-  const STRUDEL_FALLBACK_SUFFIX =
-    "\n\nThe Strudel REPL is delivered as HTML or opened in the browser.";
-
   const strudelPlayHandler = async (
-    args: z.infer<typeof strudelInputSchema>,
+    args: z.infer<typeof playLiveInputSchema>,
   ): Promise<CallToolResult> => {
     const result = await handlePlayLivePattern(args);
 
@@ -416,7 +299,7 @@ export function createServer(options?: ServerOptions): McpServer {
           {
             type: "resource" as const,
             resource: {
-              uri: `music://strudel/${Date.now()}.html`,
+              uri: `music://strudel/${randomUUID()}.html`,
               mimeType: "text/html",
               text: html,
             },
@@ -437,7 +320,7 @@ export function createServer(options?: ServerOptions): McpServer {
         result.content = [
           {
             type: "text",
-            text: `${text}\n\nStrudel player saved and opening in browser.\nFile: ${fileUrl}`,
+            text: `${text}\n\nStrudel player saved to: ${fileUrl}\n(Attempting to open it in your browser.)`,
           },
         ];
       } catch (err) {
@@ -451,39 +334,20 @@ export function createServer(options?: ServerOptions): McpServer {
     return result;
   };
 
-  // Register play-live-pattern with fallback description (upgraded in oninitialized)
   registerAppTool(
     server,
     "play-live-pattern",
     {
       title: "Play Live Pattern",
-      description: STRUDEL_BASE_DESCRIPTION + STRUDEL_FALLBACK_SUFFIX,
-      inputSchema: strudelInputSchema,
-      _meta: { ui: { resourceUri: strudelResourceUri } },
+      description:
+        PLAY_LIVE_BASE_DESCRIPTION +
+        (inlineMode ? PLAY_LIVE_EXT_APPS_SUFFIX : PLAY_LIVE_FALLBACK_SUFFIX),
+      inputSchema: playLiveInputSchema,
+      annotations: PLAY_TOOL_ANNOTATIONS,
+      _meta: { ui: { resourceUri: STRUDEL_RESOURCE_URI } },
     },
     strudelPlayHandler,
   );
-
-  // Upgrade to ext-apps description if client supports it (in same oninitialized)
-  const originalOnInitialized = server.server.oninitialized;
-  server.server.oninitialized = () => {
-    // Run the original oninitialized (which handles play-sheet-music upgrade)
-    if (originalOnInitialized) originalOnInitialized.call(server.server);
-
-    if (clientSupportsExtApps) {
-      registerAppTool(
-        server,
-        "play-live-pattern",
-        {
-          title: "Play Live Pattern",
-          description: STRUDEL_BASE_DESCRIPTION + STRUDEL_EXT_APPS_SUFFIX,
-          inputSchema: strudelInputSchema,
-          _meta: { ui: { resourceUri: strudelResourceUri } },
-        },
-        strudelPlayHandler,
-      );
-    }
-  };
 
   // ---------------------------------------------------------------------------
   // Tool: get-strudel-guide
@@ -492,22 +356,13 @@ export function createServer(options?: ServerOptions): McpServer {
     "get-strudel-guide",
     {
       title: "Strudel Reference Guide",
-      description:
-        "Reference material for Strudel live coding (performance mode). " +
-        "Topics: mini-notation (pattern syntax), sounds (synths, 72 drum banks, 128 GM instruments), " +
-        "effects (filters, reverb, delay, FM synthesis, envelopes), " +
-        "patterns (transformations, probability, euclidean, arrangement), " +
-        "genres (complete templates: techno/house/dnb/ambient/jazz/lofi/synthwave), " +
-        "tips (tempo, common mistakes, ABC↔Strudel crossover), " +
-        "advanced (visualization, sample loading, wavetables, ZZFX, continuous signals, chord voicings).",
+      description: GET_STRUDEL_GUIDE_DESCRIPTION,
       inputSchema: z.object({
         topic: z
           .enum(STRUDEL_GUIDE_TOPICS)
-          .describe(
-            "Reference topic. Start with 'genres' for working templates, " +
-            "'sounds' for instruments, 'advanced' for visualization and sample loading.",
-          ),
+          .describe(GET_STRUDEL_GUIDE_TOPIC_DESCRIPTION),
       }),
+      annotations: GUIDE_TOOL_ANNOTATIONS,
     },
     handleGetStrudelGuide,
   );
@@ -515,83 +370,18 @@ export function createServer(options?: ServerOptions): McpServer {
   // ---------------------------------------------------------------------------
   // Tool: search-music-docs (Context7-powered semantic search)
   // ---------------------------------------------------------------------------
-  const CONTEXT7_LIBRARY_IDS: Record<string, string> = {
-    strudel: "/websites/strudel_cc",
-    abcjs: "/paulrosen/abcjs",
-  };
-
   server.registerTool(
     "search-music-docs",
     {
       title: "Search Music Documentation",
-      description:
-        "Search detailed documentation for Strudel live coding or ABC/ABCJS notation. " +
-        "Returns relevant code examples and explanations from the official docs. " +
-        "Use this when the curated guides (get-strudel-guide, get-music-guide) don't " +
-        "cover what you need — for specific functions, advanced techniques, or when " +
-        "you're unsure about syntax. Powered by semantic search over strudel.cc and ABCJS docs.",
-      inputSchema: z.object({
-        query: z
-          .string()
-          .describe(
-            "What you want to know. Be specific. " +
-              "Good: 'how to use FM synthesis with envelope' or 'chop and slice sample manipulation'. " +
-              "Bad: 'effects' or 'help'.",
-          ),
-        library: z
-          .enum(["strudel", "abcjs"])
-          .default("strudel")
-          .describe(
-            "Which library to search: 'strudel' for live coding patterns, 'abcjs' for sheet music notation.",
-          ),
+      description: SEARCH_DOCS_DESCRIPTION,
+      inputSchema: searchDocsInputSchema,
+      annotations: SEARCH_TOOL_ANNOTATIONS,
+    },
+    async ({ query, library }) =>
+      searchMusicDocs(query, library, {
+        apiKey: process.env.CONTEXT7_API_KEY,
       }),
-    },
-    async ({ query, library }) => {
-      const libraryId = CONTEXT7_LIBRARY_IDS[library] ?? CONTEXT7_LIBRARY_IDS.strudel;
-      const params = new URLSearchParams({ libraryId, query, type: "txt" });
-
-      try {
-        const res = await fetch(
-          `https://context7.com/api/v2/context?${params}`,
-        );
-
-        if (!res.ok) {
-          return {
-            isError: true,
-            content: [
-              {
-                type: "text",
-                text: `Documentation search failed (${res.status}). Try the curated guides instead.`,
-              },
-            ],
-          };
-        }
-
-        const text = await res.text();
-        if (!text || text.trim().length === 0) {
-          return {
-            content: [
-              {
-                type: "text",
-                text: `No results for "${query}" in ${library} docs. Try rephrasing or use the curated guides.`,
-              },
-            ],
-          };
-        }
-
-        return { content: [{ type: "text", text }] };
-      } catch (err) {
-        return {
-          isError: true,
-          content: [
-            {
-              type: "text",
-              text: `Search error: ${(err as Error).message}. Use get-strudel-guide or get-music-guide as fallback.`,
-            },
-          ],
-        };
-      }
-    },
   );
 
   // ---------------------------------------------------------------------------
@@ -614,38 +404,21 @@ export function createServer(options?: ServerOptions): McpServer {
   // ---------------------------------------------------------------------------
   registerAppResource(
     server,
-    strudelResourceUri,
-    strudelResourceUri,
+    STRUDEL_RESOURCE_URI,
+    STRUDEL_RESOURCE_URI,
     { mimeType: RESOURCE_MIME_TYPE, description: "Strudel Live Pattern REPL" },
     async (): Promise<ReadResourceResult> => {
       const html = await fs.readFile(
         path.join(DIST_DIR, "strudel-app.html"),
         "utf-8",
       );
-
       return {
         contents: [
           {
-            uri: strudelResourceUri,
+            uri: STRUDEL_RESOURCE_URI,
             mimeType: RESOURCE_MIME_TYPE,
             text: html,
-            _meta: {
-              ui: {
-                csp: {
-                  resourceDomains: [
-                    "https://unpkg.com",
-                    "https://cdn.jsdelivr.net",
-                  ],
-                  connectDomains: [
-                    "https://unpkg.com",
-                    "https://raw.githubusercontent.com",
-                    "https://cdn.jsdelivr.net",
-                    "https://felixroos.github.io",
-                    "https://tidalcycles.github.io",
-                  ],
-                },
-              },
-            },
+            _meta: { ui: { csp: { ...STRUDEL_CSP } } },
           },
         ],
       };

--- a/src/browser-fallback.ts
+++ b/src/browser-fallback.ts
@@ -2,7 +2,8 @@
  * Browser fallback for non-UI MCP clients.
  * Generates a self-contained HTML player and opens it in the default browser.
  */
-import { exec } from "node:child_process";
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
@@ -434,20 +435,20 @@ export async function openPlayerInBrowser(
   const outDir = outputDir ?? path.join(os.homedir(), "Desktop", "mcp-music-studio");
   await fs.mkdir(outDir, { recursive: true });
 
-  const filename = `player-${Date.now()}.html`;
+  const filename = `player-${randomUUID()}.html`;
   const filepath = path.join(outDir, filename);
   await fs.writeFile(filepath, html, "utf-8");
 
-  // Try to open in default browser (may fail in sandboxed environments)
+  // Try to open in default browser (may fail in sandboxed environments).
+  // Use execFile with an argv array so no shell parses the path.
   const platform = process.platform;
-  let cmd: string;
-  if (platform === "darwin") cmd = `open "${filepath}"`;
-  else if (platform === "win32") cmd = `start "" "${filepath}"`;
-  else cmd = `xdg-open "${filepath}"`;
-
-  exec(cmd, (err) => {
+  const openErr = (err: Error | null) => {
     if (err) console.error("Failed to open browser:", err.message);
-  });
+  };
+  if (platform === "darwin") execFile("open", [filepath], openErr);
+  else if (platform === "win32")
+    execFile("cmd", ["/c", "start", "", filepath], openErr);
+  else execFile("xdg-open", [filepath], openErr);
 
   return filepath;
 }

--- a/src/mcp-app.css
+++ b/src/mcp-app.css
@@ -9,6 +9,7 @@
   --color-border: #e5e7eb;
 }
 
+/* Dark palette — shared by OS preference and host-driven theme. */
 @media (prefers-color-scheme: dark) {
   :root {
     --color-bg: #111827;
@@ -20,6 +21,31 @@
     --color-card-bg: #1f2937;
     --color-border: #374151;
   }
+}
+
+/* Host-driven theme (applyDocumentTheme sets data-theme on <html>).
+   Explicit attribute wins over the OS media query so an in-app theme
+   different from the OS renders correctly. */
+:root[data-theme="dark"] {
+  --color-bg: #111827;
+  --color-text: #f9fafb;
+  --color-text-muted: #9ca3af;
+  --color-primary: #3b82f6;
+  --color-success: #34d399;
+  --color-danger: #f87171;
+  --color-card-bg: #1f2937;
+  --color-border: #374151;
+}
+
+:root[data-theme="light"] {
+  --color-bg: #ffffff;
+  --color-text: #1f2937;
+  --color-text-muted: #6b7280;
+  --color-primary: #2563eb;
+  --color-success: #10b981;
+  --color-danger: #ef4444;
+  --color-card-bg: #f9fafb;
+  --color-border: #e5e7eb;
 }
 
 html,
@@ -144,12 +170,48 @@ body {
   background: var(--color-card-bg);
 }
 
-/* Note highlighting during playback */
+/* Loading skeleton / spinner (pre-render and streaming states) */
+.loading-skeleton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  min-height: 160px;
+  color: var(--color-text-muted);
+  font-size: 0.875rem;
+}
+
+.spinner {
+  width: 18px;
+  height: 18px;
+  border: 2px solid var(--color-border);
+  border-top-color: var(--color-primary);
+  border-radius: 50%;
+  animation: spinner-rotate 0.7s linear infinite;
+}
+
+@keyframes spinner-rotate {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner {
+    animation-duration: 2s;
+  }
+}
+
+/* Note highlighting during playback.
+   Color fill is the primary cue; a non-color emphasis (bold stroke) is
+   added so the highlight is perceivable without relying on color alone. */
 .note-playing path,
 .note-playing circle,
 .note-playing ellipse,
 .note-playing polygon {
   fill: var(--color-primary) !important;
+  stroke: var(--color-primary) !important;
+  stroke-width: 1.5px;
   transition: fill 0.08s ease;
 }
 

--- a/src/mcp-app.ts
+++ b/src/mcp-app.ts
@@ -2,7 +2,12 @@
  * @file Sheet Music App — renders ABC notation with abcjs, multi-instrument audio,
  *       style presets, note highlighting, and playback controls.
  */
-import { App, type McpUiHostContext } from "@modelcontextprotocol/ext-apps";
+import {
+  App,
+  applyDocumentTheme,
+  applyHostStyleVariables,
+  type McpUiHostContext,
+} from "@modelcontextprotocol/ext-apps";
 import ABCJS from "abcjs";
 import type { NoteTimingEvent, CursorControl, SynthOptions } from "abcjs";
 import "abcjs/abcjs-audio.css";
@@ -17,6 +22,7 @@ import {
   prepareToolInput,
 } from "./music-logic";
 import { audioBufferToWavBase64 } from "./wav-encoder";
+import { VERSION } from "./version";
 
 // =============================================================================
 // State
@@ -178,6 +184,7 @@ const fullscreenBtn = document.createElement("button");
 fullscreenBtn.className = "toolbar-btn";
 fullscreenBtn.textContent = "⛶";
 fullscreenBtn.title = "Toggle fullscreen";
+fullscreenBtn.setAttribute("aria-label", "Toggle fullscreen");
 fullscreenBtn.addEventListener("click", () => {
   appInstance?.requestDisplayMode({ mode: "fullscreen" });
 });
@@ -191,8 +198,18 @@ const downloadBtn = document.createElement("button");
 downloadBtn.className = "toolbar-btn";
 downloadBtn.textContent = "↓";
 downloadBtn.title = "Download audio (WAV)";
+downloadBtn.setAttribute("aria-label", "Download audio as WAV");
 downloadBtn.disabled = true;
 toolbarEl.appendChild(downloadBtn);
+
+// Whether the host supports host-mediated downloads (set after connect).
+// On hosts without this capability (e.g. Claude mobile), the button stays
+// hidden so users don't hit a -32601 "method not found" error.
+// Default false: stay disabled until the capability is confirmed (avoids a
+// race window where the button is clickable before connect() resolves).
+let downloadSupported = false;
+// Whether the host supports widget→chat messages (ui/message). Gates the Send button.
+let messageSupported = false;
 
 function extractTitle(abc: string | null): string {
   if (!abc) return "music";
@@ -235,12 +252,69 @@ downloadBtn.addEventListener("click", async () => {
 });
 
 // =============================================================================
+// Send to Chat Button (roundtrip edited ABC back to the conversation)
+// =============================================================================
+
+const sendBtn = document.createElement("button");
+sendBtn.className = "toolbar-btn";
+sendBtn.textContent = "↗";
+sendBtn.title = "Send this ABC to chat";
+sendBtn.setAttribute("aria-label", "Send this ABC notation to the chat");
+sendBtn.disabled = true;
+// Start hidden; revealed only after the host confirms ui/message support
+// (matches the Strudel widget, avoids a flash on unsupported hosts).
+sendBtn.hidden = true;
+toolbarEl.appendChild(sendBtn);
+
+sendBtn.addEventListener("click", async () => {
+  if (!state.currentAbc) return;
+  sendBtn.disabled = true;
+  sendBtn.textContent = "...";
+  try {
+    await app.sendMessage({
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: "Here's my ABC notation:\n```\n" + state.currentAbc + "\n```",
+        },
+      ],
+    });
+  } catch (err) {
+    setStatus(`Send failed: ${(err as Error).message}`, true);
+  } finally {
+    sendBtn.disabled = false;
+    sendBtn.textContent = "↗";
+  }
+});
+
+// =============================================================================
 // ABC Rendering
 // =============================================================================
 
 function setStatus(text: string, isError = false): void {
   statusEl.textContent = text;
   statusEl.classList.toggle("error", isError);
+}
+
+// Toggle a lightweight loading skeleton/spinner in the sheet area.
+// Used during streaming before the score is renderable.
+function setLoading(text: string): void {
+  setStatus(text);
+  if (!state.visualObj) {
+    // Build via DOM API (not innerHTML) so this never becomes an injection sink.
+    const skeleton = document.createElement("div");
+    skeleton.className = "loading-skeleton";
+    skeleton.setAttribute("role", "status");
+    skeleton.setAttribute("aria-live", "polite");
+    const spinner = document.createElement("span");
+    spinner.className = "spinner";
+    spinner.setAttribute("aria-hidden", "true");
+    const label = document.createElement("span");
+    label.textContent = text;
+    skeleton.append(spinner, label);
+    sheetMusicEl.replaceChildren(skeleton);
+  }
 }
 
 async function renderAbc(
@@ -292,16 +366,19 @@ async function renderAbc(
 
     // Show toolbar once we have content
     toolbarEl.classList.add("visible");
-    downloadBtn.disabled = false;
+    downloadBtn.disabled = !downloadSupported;
+    sendBtn.disabled = !messageSupported;
 
     // Autoplay — attempt to start playback immediately
-    // (may be blocked by browser autoplay policy until user clicks)
-    try {
-      state.synthControl.play();
-      setStatus("Playing...");
-    } catch {
-      setStatus("Ready to play!");
-    }
+    // (may be blocked by browser autoplay policy until user clicks).
+    // play() returns a Promise, so a synchronous try/catch never fires —
+    // attach to the promise to report the real outcome.
+    (state.synthControl.play() as Promise<void> | undefined)
+      ?.then(() => setStatus("Playing..."))
+      .catch((e) => {
+        console.debug("Autoplay blocked:", e);
+        setStatus("Click ▶ to play");
+      });
   } catch (error) {
     console.error("Render error:", error);
     setStatus(`Error: ${(error as Error).message}`, true);
@@ -313,7 +390,7 @@ async function renderAbc(
 // MCP Apps SDK Integration
 // =============================================================================
 
-const app = new App({ name: "Music Studio", version: "0.3.0" });
+const app = new App({ name: "Music Studio", version: VERSION });
 appInstance = app;
 
 // Handle complete tool input
@@ -357,7 +434,7 @@ app.ontoolinputpartial = (params) => {
 
   // Only attempt render if we have at least a key signature (minimum viable ABC)
   if (!abcNotation.match(/K:[^\n]+/)) {
-    setStatus("Composing...");
+    setLoading("Composing…");
     return;
   }
 
@@ -391,7 +468,52 @@ app.ontoolinputpartial = (params) => {
 
 app.onerror = console.error;
 
+// Reset playback/highlight state when a compose is cancelled or torn down.
+function stopPlayback(): void {
+  try {
+    state.synthControl?.pause();
+  } catch {
+    // synthControl may not be loaded yet — ignore
+  }
+  state.highlightedEls.forEach((el) => el.classList.remove("note-playing"));
+  state.highlightedEls = [];
+}
+
+// Cancel any pending debounced partial render so a stale timer can't fire
+// after a cancel/teardown and re-render old ABC or reset the status.
+function cancelPartialRender(): void {
+  if (partialRenderTimer) {
+    clearTimeout(partialRenderTimer);
+    partialRenderTimer = null;
+  }
+  lastPartialAbc = "";
+}
+
+// Tool cancelled — clear the stale "Composing…" status so the UI isn't stuck.
+app.ontoolcancelled = (params) => {
+  stopPlayback();
+  cancelPartialRender();
+  const reason = params?.reason ? ` (${params.reason})` : "";
+  setStatus(`Composition cancelled${reason}.`);
+};
+
+// Host is tearing down this instance — stop audio so a discarded widget
+// leaves nothing playing.
+app.onteardown = () => {
+  stopPlayback();
+  cancelPartialRender();
+  return {};
+};
+
 function handleHostContextChanged(ctx: McpUiHostContext) {
+  // Follow the host-driven theme (which may differ from the OS preference).
+  if (ctx.theme) {
+    applyDocumentTheme(ctx.theme);
+  }
+  // Apply host-provided CSS variable tokens, if any.
+  if (ctx.styles?.variables) {
+    applyHostStyleVariables(ctx.styles.variables);
+  }
   if (ctx.safeAreaInsets) {
     mainEl.style.paddingTop = `${ctx.safeAreaInsets.top}px`;
     mainEl.style.paddingRight = `${ctx.safeAreaInsets.right}px`;
@@ -403,6 +525,25 @@ function handleHostContextChanged(ctx: McpUiHostContext) {
 app.onhostcontextchanged = handleHostContextChanged;
 
 app.connect().then(() => {
+  // Gate the download button on host capability — Claude mobile lacks
+  // downloadFile, so calling it returns -32601. Hide the button there.
+  downloadSupported = Boolean(app.getHostCapabilities()?.downloadFile);
+  if (!downloadSupported) {
+    downloadBtn.hidden = true;
+    downloadBtn.disabled = true;
+    downloadBtn.title = "Audio download isn't supported by this host";
+  }
+
+  // Gate the Send-to-chat button on the host's message capability so it can't
+  // throw -32601 on hosts that don't advertise ui/message. Reveal only when supported.
+  messageSupported = Boolean(app.getHostCapabilities()?.message);
+  if (messageSupported) {
+    sendBtn.hidden = false;
+  } else {
+    sendBtn.disabled = true;
+    sendBtn.title = "Sending to chat isn't supported by this host";
+  }
+
   const ctx = app.getHostContext();
   if (ctx) {
     handleHostContextChanged(ctx);

--- a/src/server-logic.ts
+++ b/src/server-logic.ts
@@ -1,5 +1,6 @@
 import ABCJS from "abcjs";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { PLAY_SHEET_NEUTRAL_TEXT } from "./shared/tool-defs.js";
 
 export type ParseOnlyResult = {
   warnings?: string[];
@@ -14,7 +15,9 @@ export function createPlaySheetMusicResult(
   const [{ warnings } = {}] = parseOnly(abcNotation);
 
   if (warnings && warnings.length > 0) {
-    const messages = warnings.map((warning) => warning.replace(/<[^>]*>/g, ""));
+    const messages = warnings.map((warning) =>
+      String(warning).replace(/<[^>]*>/g, ""),
+    );
     const hasErrors = messages.some(
       (message) =>
         message.includes("Expected") ||
@@ -44,7 +47,13 @@ export function createPlaySheetMusicResult(
     };
   }
 
+  // Compose from the shared constant (single source of truth) + a local-only hint.
   return {
-    content: [{ type: "text", text: "Music parsed successfully. Playing!" }],
+    content: [
+      {
+        type: "text",
+        text: `${PLAY_SHEET_NEUTRAL_TEXT} Re-run with --render-mode browser to open a playable version in your browser.`,
+      },
+    ],
   };
 }

--- a/src/shared/parse-client.ts
+++ b/src/shared/parse-client.ts
@@ -1,0 +1,18 @@
+// Pure user-agent → client classifier for analytics. Extracted from the worker
+// so it can be unit-tested without the worker's html/agents imports.
+
+export function parseClient(ua: string): string {
+  const lower = ua.toLowerCase();
+  if (lower === "claude-user") return "claude-ai";
+  if (lower.includes("claude-ai") || lower.includes("claude.ai"))
+    return "claude-ai";
+  if (lower.includes("claude-code") || lower.includes("claude code"))
+    return "claude-code";
+  if (lower.includes("cursor")) return "cursor";
+  if (lower.includes("gemini")) return "gemini";
+  if (lower.includes("windsurf")) return "windsurf";
+  if (lower.includes("cline")) return "cline";
+  if (lower.includes("smithery")) return "smithery";
+  if (lower.includes("mcp-remote")) return "mcp-remote";
+  return "unknown";
+}

--- a/src/shared/tool-defs.ts
+++ b/src/shared/tool-defs.ts
@@ -1,0 +1,529 @@
+// =============================================================================
+// Shared tool definitions — single source of truth for both transports
+//
+// Consumed by the local stdio/HTTP server (server.ts) and the Cloudflare Worker
+// (worker/src/index.ts) so tool names, schemas, descriptions, annotations,
+// _meta, instructions, and the search-docs behavior never drift between them.
+//
+// Dependency-light by design: no Node.js or ABCJS imports, so the Worker bundle
+// can import it. Transport-specific wiring (render-mode branches, KV cache,
+// fs/child_process) stays in each transport's own file.
+// =============================================================================
+
+import { z } from "zod";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { STYLE_NAMES } from "../music-logic.js";
+import { DEFAULT_ABC_NOTATION } from "../abc-guide.js";
+
+// -----------------------------------------------------------------------------
+// Resource URIs
+// -----------------------------------------------------------------------------
+
+export const SHEET_RESOURCE_URI = "ui://sheet-music/mcp-app.html";
+export const STRUDEL_RESOURCE_URI = "ui://strudel/strudel-app.html";
+
+// -----------------------------------------------------------------------------
+// Server-level guidance (flow hint for the model)
+// -----------------------------------------------------------------------------
+
+/**
+ * Advertise ext-apps UI support on the low-level server, symmetrically across
+ * both transports. The `extensions` capability isn't in every bundled SDK's
+ * ServerCapabilities type, so the param is widened here to keep the call site
+ * clean in both server.ts and the worker.
+ */
+export function advertiseUiExtension(rawServer: {
+  registerCapabilities(capabilities: unknown): void;
+}): void {
+  rawServer.registerCapabilities({
+    extensions: { "io.modelcontextprotocol/ui": {} },
+  });
+}
+
+export const SERVER_INSTRUCTIONS =
+  "Music Studio renders music in interactive widgets. Two creative modes: " +
+  "play-sheet-music (write ABC notation → sheet music + multi-instrument audio) and " +
+  "play-live-pattern (write Strudel/TidalCycles code → an editable live-coding REPL). " +
+  "Before composing, consult the reference tools: get-music-guide (ABC — start with " +
+  "topic 'genres' for templates, 'styles' for accompaniment presets, 'instruments' for the list) " +
+  "or get-strudel-guide (Strudel — 'genres', 'sounds', 'effects'). Use search-music-docs only " +
+  "when the curated guides don't cover something. For ABC accompaniment, include chord symbols " +
+  '("C", "Am7") above the notes and set a style.';
+
+// -----------------------------------------------------------------------------
+// Tool annotations (MCP hints — all tools here are read-only, non-destructive)
+// -----------------------------------------------------------------------------
+
+export const PLAY_TOOL_ANNOTATIONS = {
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+  openWorldHint: false,
+} as const;
+
+export const GUIDE_TOOL_ANNOTATIONS = {
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+  openWorldHint: false,
+} as const;
+
+export const SEARCH_TOOL_ANNOTATIONS = {
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: false,
+  openWorldHint: true, // hits an external API (context7.com)
+} as const;
+
+// -----------------------------------------------------------------------------
+// CSP _meta for the UI resources
+// -----------------------------------------------------------------------------
+
+export const SHEET_CSP: { connectDomains: string[] } = {
+  connectDomains: ["https://paulrosen.github.io"],
+};
+
+export const STRUDEL_CSP: { resourceDomains: string[]; connectDomains: string[] } = {
+  resourceDomains: ["https://unpkg.com", "https://cdn.jsdelivr.net"],
+  connectDomains: [
+    "https://unpkg.com",
+    "https://raw.githubusercontent.com",
+    "https://cdn.jsdelivr.net",
+    "https://felixroos.github.io",
+    "https://tidalcycles.github.io",
+  ],
+};
+
+// -----------------------------------------------------------------------------
+// play-sheet-music
+// -----------------------------------------------------------------------------
+
+export const PLAY_SHEET_BASE_DESCRIPTION =
+  "Compose and play sheet music with visual notation, multi-instrument audio, " +
+  "and style presets. Write ABC notation for melodies, arrangements, harmonized " +
+  "pieces, or well-known tunes. Add a style (rock, jazz, bossa, waltz, folk...) " +
+  "for automatic drums, bass, and chord accompaniment. " +
+  "Returns a parse-status confirmation and renders the player; it does not return raw audio. " +
+  "Use get-music-guide for genre templates, instrument lists, and ABC syntax reference.";
+
+export const PLAY_SHEET_EXT_APPS_SUFFIX =
+  "\n\nThe music player renders inline with interactive playback controls.";
+
+export const PLAY_SHEET_FALLBACK_SUFFIX =
+  "\n\nThe music player is delivered as HTML or opened in the browser automatically.";
+
+/**
+ * Honest confirmation for transports that don't server-side validate ABC (the worker).
+ * Deliberately does NOT assert that anything played — a terminal client sees only this
+ * text (no widget), so claiming playback would mislead the agent.
+ */
+export const PLAY_SHEET_NEUTRAL_TEXT =
+  "Sheet music ready. It renders as an interactive, playable score in MCP-app hosts " +
+  "(e.g. Claude Desktop, claude.ai). If you don't see a player here, this client can't play it " +
+  "inline, so nothing has played yet.";
+
+export const playSheetInputSchema = z.object({
+  abcNotation: z
+    .string()
+    .default(DEFAULT_ABC_NOTATION)
+    .describe(
+      'ABC notation string. Include chord symbols ("C", "Am7") above notes for auto-accompaniment with style presets.',
+    ),
+  title: z
+    .string()
+    .optional()
+    .describe("Piece title (overrides T: in ABC). Displayed in the widget header."),
+  instrument: z
+    .string()
+    .optional()
+    .describe(
+      "Default instrument (e.g. 'Flute', 'Cello', 'Acoustic Grand Piano', 'Alto Sax'). " +
+        "Use get-music-guide with topic 'instruments' for the full list.",
+    ),
+  style: z
+    .enum(STYLE_NAMES)
+    .optional()
+    .describe(
+      "Accompaniment style. Adds drums, bass, and chord patterns automatically. " +
+        'Your ABC needs chord symbols ("C", "Am") for accompaniment to work. ' +
+        "Options: rock, jazz, bossa, waltz, march, reggae, folk, classical.",
+    ),
+  tempo: z
+    .number()
+    .min(40)
+    .max(240)
+    .optional()
+    .describe("Tempo in BPM (40-240). Overrides Q: in ABC notation."),
+  swing: z
+    .number()
+    .min(0)
+    .max(100)
+    .optional()
+    .describe(
+      "Swing percentage (0-100). 0=straight, 33=light swing, 66=heavy swing. Great for jazz and blues.",
+    ),
+  transpose: z
+    .number()
+    .min(-12)
+    .max(12)
+    .optional()
+    .describe("Transpose by semitones (-12 to 12). Positive=higher, negative=lower."),
+});
+
+// -----------------------------------------------------------------------------
+// play-live-pattern
+// -----------------------------------------------------------------------------
+
+export const PLAY_LIVE_BASE_DESCRIPTION =
+  "Live-code music patterns using TidalCycles mini-notation in JavaScript. " +
+  "Layer drums, synths, and bass with stack(). Choose from 72 drum machine banks, " +
+  "128 GM instruments, built-in synths, and a full effects chain. " +
+  "Patterns play in a REPL the user can edit directly. " +
+  "Use get-strudel-guide for genre templates, sound references, and advanced features " +
+  "like visualization, arrangement, and sample loading.";
+
+export const PLAY_LIVE_EXT_APPS_SUFFIX =
+  "\n\nThe Strudel REPL renders inline with an editable code editor, " +
+  "visualizations, and playback controls.";
+
+export const PLAY_LIVE_FALLBACK_SUFFIX =
+  "\n\nThe Strudel REPL is delivered as HTML or opened in the browser.";
+
+export const playLiveInputSchema = z.object({
+  code: z
+    .string()
+    .describe(
+      "Strudel pattern code. Uses TidalCycles mini-notation in JavaScript. " +
+        "Use stack() to layer drums, bass, and melody. " +
+        "Set tempo with setcps(bpm/60/4) or use the bpm parameter.",
+    ),
+  title: z
+    .string()
+    .optional()
+    .describe("Pattern title displayed in the widget header (e.g. 'Midnight Rain')."),
+  bpm: z
+    .number()
+    .min(40)
+    .max(300)
+    .optional()
+    .describe("Tempo in BPM (40-300). Converts to setcps() automatically."),
+  autoplay: z
+    .boolean()
+    .optional()
+    .describe(
+      "Start playing immediately (default: true). May require user click due to browser autoplay policy.",
+    ),
+});
+
+/**
+ * Build the play-live-pattern tool result. Strudel code is evaluated client-side
+ * in the REPL, so the server cannot confirm it runs — the wording is deliberately
+ * non-asserting so the agent doesn't over-trust a silent failure.
+ */
+export function buildPlayLiveResult(args: { code: string; title?: string }): CallToolResult {
+  const label = args.title ? `"${args.title}" — ` : "";
+  return {
+    content: [
+      {
+        type: "text",
+        text:
+          `${label}Strudel pattern ready. It plays in an editable REPL widget in MCP-app hosts ` +
+          "(e.g. Claude Desktop, claude.ai). If you don't see a player here, this client can't play it " +
+          "inline, so nothing has played yet.",
+      },
+    ],
+  };
+}
+
+// -----------------------------------------------------------------------------
+// get-music-guide / get-strudel-guide descriptions
+// -----------------------------------------------------------------------------
+
+export const GET_MUSIC_GUIDE_DESCRIPTION =
+  "Returns detailed reference material for music composition. " +
+  "Topics: instruments (GM instrument list + combos), drums (patterns + percussion notes), " +
+  "abc-syntax (notation reference), arrangements (multi-voice patterns), " +
+  "genres (complete ABC templates for jazz/blues/folk/rock/bossa/classical), " +
+  "styles (what each style preset does), midi-directives (%%MIDI reference).";
+
+export const GET_MUSIC_GUIDE_TOPIC_DESCRIPTION =
+  "Reference topic. Start with 'genres' for complete examples, 'styles' to understand presets, or 'instruments' for the full instrument list.";
+
+export const GET_STRUDEL_GUIDE_DESCRIPTION =
+  "Reference material for Strudel live coding (performance mode). " +
+  "Topics: mini-notation (pattern syntax), sounds (synths, 72 drum banks, 128 GM instruments), " +
+  "effects (filters, reverb, delay, FM synthesis, envelopes), " +
+  "patterns (transformations, probability, euclidean, arrangement), " +
+  "genres (complete templates: techno/house/dnb/ambient/jazz/lofi/synthwave), " +
+  "tips (tempo, common mistakes, ABC↔Strudel crossover), " +
+  "advanced (visualization, sample loading, wavetables, ZZFX, continuous signals, chord voicings).";
+
+export const GET_STRUDEL_GUIDE_TOPIC_DESCRIPTION =
+  "Reference topic. Start with 'genres' for working templates, " +
+  "'sounds' for instruments, 'advanced' for visualization and sample loading.";
+
+// -----------------------------------------------------------------------------
+// search-music-docs — shared core (cache + key are injected per transport)
+// -----------------------------------------------------------------------------
+
+export const SEARCH_DOCS_DESCRIPTION =
+  "Search detailed documentation for Strudel live coding or ABC/ABCJS notation. " +
+  "Returns relevant code examples and explanations from the official docs. " +
+  "Use this when the curated guides (get-strudel-guide, get-music-guide) don't " +
+  "cover what you need — for specific functions, advanced techniques, or when " +
+  "you're unsure about syntax. Powered by semantic search over strudel.cc and ABCJS docs.";
+
+export const searchDocsInputSchema = z.object({
+  query: z
+    .string()
+    .describe(
+      "What you want to know. Be specific. " +
+        "Good: 'how to use FM synthesis with envelope' or 'chop and slice sample manipulation'. " +
+        "Bad: 'effects' or 'help'.",
+    ),
+  library: z
+    .enum(["strudel", "abcjs"])
+    .default("strudel")
+    .describe(
+      "Which library to search: 'strudel' for live coding patterns, 'abcjs' for sheet music notation.",
+    ),
+});
+
+export const CONTEXT7_LIBRARY_IDS: Record<"strudel" | "abcjs", string> = {
+  strudel: "/websites/strudel_cc",
+  abcjs: "/paulrosen/abcjs",
+};
+
+/** Max chars of upstream docs returned before truncation (avoids flooding context). */
+export const SEARCH_DOCS_MAX_CHARS = 12000;
+
+export interface SearchDocsDeps {
+  /** Optional Context7 API key; used to retry once with Bearer auth on HTTP 429. */
+  apiKey?: string;
+  /** Optional cache read (e.g. Cloudflare KV). Returns cached text or null. */
+  cacheGet?: (key: string) => Promise<string | null>;
+  /** Optional cache write (e.g. Cloudflare KV, 24h TTL). */
+  cachePut?: (key: string, value: string) => Promise<void>;
+  /** Truncation cap; defaults to SEARCH_DOCS_MAX_CHARS. */
+  maxChars?: number;
+}
+
+/**
+ * Shared search-music-docs implementation. Behavior is identical across
+ * transports; only the cache adapter and API key differ (injected via deps).
+ * Never reflects the raw upstream error body (status only) to avoid relaying
+ * upstream-controlled text into the model context.
+ */
+/** Max query length accepted — bounds KV-key cardinality and upstream cost. */
+export const SEARCH_DOCS_MAX_QUERY = 500;
+
+export async function searchMusicDocs(
+  query: string,
+  library: "strudel" | "abcjs",
+  deps: SearchDocsDeps = {},
+): Promise<CallToolResult> {
+  const libraryId = CONTEXT7_LIBRARY_IDS[library] ?? CONTEXT7_LIBRARY_IDS.strudel;
+  const maxChars = deps.maxChars ?? SEARCH_DOCS_MAX_CHARS;
+  // Truncate by Unicode code points (not UTF-16 units) so an astral character
+  // straddling the cap can't be split into a broken surrogate half.
+  const codePoints = Array.from(query);
+  const q =
+    codePoints.length > SEARCH_DOCS_MAX_QUERY
+      ? codePoints.slice(0, SEARCH_DOCS_MAX_QUERY).join("")
+      : query;
+  const cacheKey = `ctx7:${library}:${q}`;
+
+  if (deps.cacheGet) {
+    try {
+      const cached = await deps.cacheGet(cacheKey);
+      if (cached) return { content: [{ type: "text", text: cached }] };
+    } catch {
+      /* cache miss/unavailable — fall through to fetch */
+    }
+  }
+
+  const params = new URLSearchParams({ libraryId, query: q, type: "txt" });
+  const url = `https://context7.com/api/v2/context?${params}`;
+  const apiKey = deps.apiKey ?? "";
+
+  try {
+    let res = await fetch(url);
+    if (res.status === 429 && apiKey && apiKey.startsWith("ctx7sk")) {
+      res = await fetch(url, { headers: { Authorization: `Bearer ${apiKey}` } });
+    }
+
+    if (!res.ok) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text",
+            text: `Documentation search failed (${res.status}). Try the curated guides (get-strudel-guide, get-music-guide) instead.`,
+          },
+        ],
+      };
+    }
+
+    const raw = await res.text();
+    if (!raw || raw.trim().length === 0) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `No results found for "${q}" in ${library} docs. Try rephrasing or use the curated guides.`,
+          },
+        ],
+      };
+    }
+
+    let text = raw;
+    if (text.length > maxChars) {
+      text =
+        text.slice(0, maxChars) +
+        `\n\n…[results truncated at ${maxChars} chars — refine your query for more specific snippets]`;
+    }
+
+    if (deps.cachePut) {
+      try {
+        await deps.cachePut(cacheKey, text);
+      } catch {
+        /* cache write best-effort */
+      }
+    }
+
+    return { content: [{ type: "text", text }] };
+  } catch (err) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: `Documentation search error: ${(err as Error).message}. Use get-strudel-guide or get-music-guide as fallback.`,
+        },
+      ],
+    };
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Prompts — slash-command / menu entry points (user-controlled primitive)
+//
+// Shared by both transports. Handlers are pure message builders (no side
+// effects), templated to scaffold the right tool-call flow for the model while
+// giving humans a discoverable starting point.
+// -----------------------------------------------------------------------------
+
+type PromptResult = {
+  messages: { role: "user"; content: { type: "text"; text: string } }[];
+};
+
+function userText(text: string): PromptResult {
+  return { messages: [{ role: "user", content: { type: "text", text } }] };
+}
+
+interface PromptDef {
+  name: string;
+  config: {
+    title: string;
+    description: string;
+    argsSchema: Record<string, z.ZodTypeAny>;
+  };
+  build: (args: Record<string, string | undefined>) => PromptResult;
+}
+
+export const MUSIC_PROMPTS: PromptDef[] = [
+  {
+    name: "compose-beat",
+    config: {
+      title: "Compose a beat",
+      description:
+        "Generate and play a Strudel live-coding pattern in a given genre.",
+      argsSchema: {
+        genre: z
+          .string()
+          .describe(
+            "Genre, e.g. techno, house, dnb, lofi, ambient, synthwave, jazz",
+          ),
+        mood: z
+          .string()
+          .optional()
+          .describe("Optional vibe, e.g. dark, dreamy, energetic, chill"),
+      },
+    },
+    build: (args) =>
+      userText(
+        `Compose a ${args.mood ? `${args.mood} ` : ""}${args.genre ?? "lofi"} pattern and play it with the play-live-pattern tool. ` +
+          `First call get-strudel-guide with topic "genres" for a working ${args.genre ?? "lofi"} template, then adapt it — ` +
+          `use stack() to layer drums, bass, and melody, and set a fitting tempo with setcps().`,
+      ),
+  },
+  {
+    name: "harmonize-melody",
+    config: {
+      title: "Harmonize a melody",
+      description:
+        "Add chords/accompaniment to an ABC melody and play it as sheet music.",
+      argsSchema: {
+        melody: z.string().describe("ABC notation of the melody to harmonize"),
+        style: z
+          .string()
+          .optional()
+          .describe(
+            "Optional accompaniment style: rock, jazz, bossa, waltz, march, reggae, folk, classical",
+          ),
+      },
+    },
+    build: (args) =>
+      userText(
+        `Harmonize this melody by adding chord symbols (e.g. "C", "Am7") above the notes` +
+          `${args.style ? ` and applying the "${args.style}" accompaniment style` : ""}, ` +
+          `then play it with the play-sheet-music tool. If unsure which chords fit, call get-music-guide with topic "genres" for examples.\n\n` +
+          `Melody (ABC):\n\`\`\`\n${args.melody ?? "X:1\nK:C\nCDEF GABc|"}\n\`\`\``,
+      ),
+  },
+  {
+    name: "arrange-tune",
+    config: {
+      title: "Arrange a tune",
+      description:
+        "Turn a melody or musical idea into a fuller multi-voice arrangement and play it.",
+      argsSchema: {
+        tune: z
+          .string()
+          .describe(
+            "ABC notation, or a text description of the tune/idea to arrange",
+          ),
+        instrumentation: z
+          .string()
+          .optional()
+          .describe(
+            "Optional desired instruments/voices, e.g. 'flute + cello + piano'",
+          ),
+      },
+    },
+    build: (args) =>
+      userText(
+        `Arrange this into a fuller multi-voice piece${args.instrumentation ? ` for ${args.instrumentation}` : ""} ` +
+          `and play it with the play-sheet-music tool. Add complementary voices (bass line, inner harmony), include chord symbols, ` +
+          `and consider an accompaniment style. Call get-music-guide with topic "arrangements" for multi-voice ABC patterns if needed.\n\n` +
+          `Starting point:\n\`\`\`\n${args.tune ?? "(describe or paste a melody)"}\n\`\`\``,
+      ),
+  },
+];
+
+/**
+ * Register the music prompts on a server. Method syntax (not an arrow property)
+ * keeps the param bivariant so it accepts both transports' separately-bundled
+ * McpServer types.
+ */
+export function registerMusicPrompts(server: {
+  registerPrompt(name: string, config: unknown, cb: unknown): unknown;
+}): void {
+  for (const p of MUSIC_PROMPTS) {
+    server.registerPrompt(
+      p.name,
+      p.config,
+      (args: Record<string, string | undefined>) => p.build(args),
+    );
+  }
+}

--- a/src/strudel-app.css
+++ b/src/strudel-app.css
@@ -122,6 +122,35 @@ html, body {
   min-height: 350px;
 }
 
+/* CDN load-failure recovery affordance */
+.cdn-error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  min-height: 350px;
+  padding: 24px;
+  text-align: center;
+  color: var(--text-secondary);
+}
+
+.cdn-error .retry-btn {
+  padding: 8px 20px;
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--accent);
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.cdn-error .retry-btn:hover {
+  background: var(--accent);
+  color: white;
+}
+
 /* ==========================================================================
    Layout fixes for @strudel/repl in ext-apps iframe
 

--- a/src/strudel-app.ts
+++ b/src/strudel-app.ts
@@ -11,14 +11,16 @@
 import "./strudel-app.css";
 import { App } from "@modelcontextprotocol/ext-apps";
 import { audioBufferToWavBase64 } from "./wav-encoder";
+import { VERSION } from "./version";
 
 const STRUDEL_CDN = "https://unpkg.com/@strudel/repl@1.3.0";
 
-const app = new App({ name: "Strudel Live Pattern", version: "0.3.0" });
+const app = new App({ name: "Strudel Live Pattern", version: VERSION });
 
 const playBtn = document.getElementById("play-btn") as HTMLButtonElement;
 const recordBtn = document.getElementById("record-btn") as HTMLButtonElement;
 const downloadBtn = document.getElementById("download-btn") as HTMLButtonElement;
+const sendBtn = document.getElementById("send-btn") as HTMLButtonElement;
 const fullscreenBtn = document.getElementById("fullscreen-btn") as HTMLButtonElement;
 const statusEl = document.getElementById("status")!;
 const container = document.getElementById("strudel-container")!;
@@ -28,11 +30,20 @@ let currentCode = "";
 let isPlaying = false;
 let cdnLoaded = false;
 
+// Host capabilities (populated after connect)
+let canDownload = false;
+// Last args from renderPattern, so a CDN retry can re-run the same pattern
+let lastRenderArgs: Record<string, unknown> | null = null;
+
 // Recording state
 let mediaRecorder: MediaRecorder | null = null;
 let recordedChunks: Blob[] = [];
 let isRecording = false;
 let recordingStream: MediaStream | null = null;
+// The master-output node the tap is connected to, and the tap destination,
+// so teardown can disconnect precisely the tap (not the speakers).
+let recordingMasterGain: AudioNode | null = null;
+let recordingDest: AudioNode | null = null;
 
 // Hint to the OS that this app produces audio playback
 if ("audioSession" in navigator) {
@@ -42,6 +53,27 @@ if ("audioSession" in navigator) {
 function getEditor(): any {
   return (editorEl as any)?.editor ?? null;
 }
+
+/**
+ * Read the LIVE editor buffer (the user may have edited the code in the REPL).
+ * The Strudel REPL editor exposes the buffer in different ways across versions;
+ * fall back to the tracked currentCode if no live getter is available.
+ */
+function getLiveCode(): string {
+  const ed = getEditor();
+  try {
+    if (typeof ed?.getCode === "function") return ed.getCode();
+    if (typeof ed?.code === "string") return ed.code;
+    // CodeMirror 6 instance held by the StrudelMirror editor
+    const cm = ed?.editor ?? ed?.view;
+    const doc = cm?.state?.doc;
+    if (doc && typeof doc.toString === "function") return doc.toString();
+  } catch { /* fall through to tracked code */ }
+  return currentCode;
+}
+
+// Set when prebake() soundfont registration fails — audio may be silent/absent.
+let soundfontWarning = false;
 
 async function loadStrudelCDN(): Promise<void> {
   if (cdnLoaded) return;
@@ -55,7 +87,12 @@ async function loadStrudelCDN(): Promise<void> {
       try {
         const strudel = (window as any).strudel;
         if (strudel?.prebake) await strudel.prebake();
-      } catch { /* non-fatal */ }
+        soundfontWarning = false;
+      } catch {
+        // Non-fatal: the REPL still works, but soundfonts may be unavailable.
+        // Surfaced to the user instead of silently swallowed (see renderPattern).
+        soundfontWarning = true;
+      }
       resolve();
     };
     script.onerror = () => reject(new Error("Failed to load Strudel REPL"));
@@ -145,6 +182,8 @@ function setupRecordingTap(): MediaStream | null {
     const masterGain = controller?.output?.destinationGain;
     if (masterGain?.connect) {
       masterGain.connect(dest);
+      recordingMasterGain = masterGain;
+      recordingDest = dest;
       return dest.stream;
     }
     return null;
@@ -205,6 +244,10 @@ function stopRecording(): void {
 
 async function handleDownload(): Promise<void> {
   if (recordedChunks.length === 0) return;
+  if (!canDownload) {
+    setStatus("Download not supported on this host", "error");
+    return;
+  }
 
   downloadBtn.disabled = true;
   downloadBtn.textContent = "...";
@@ -241,16 +284,55 @@ async function handleDownload(): Promise<void> {
 // Pattern Rendering
 // =============================================================================
 
+/**
+ * Show a visible retry affordance when the Strudel REPL CDN script fails to
+ * load. Re-runs the last pattern (or a no-op message) on click instead of
+ * leaving the widget at a dead-end error status.
+ */
+function showCdnError(): void {
+  container.replaceChildren();
+  // The previous <strudel-editor> (if any) was just detached — drop the ref so
+  // a retry creates a fresh element instead of calling setCode on a dead node.
+  editorEl = null;
+  const box = document.createElement("div");
+  box.className = "cdn-error";
+
+  const msg = document.createElement("p");
+  msg.textContent =
+    "Couldn't load the Strudel player (network or CDN issue).";
+  box.appendChild(msg);
+
+  const retry = document.createElement("button");
+  retry.className = "retry-btn";
+  retry.textContent = "Retry loading";
+  retry.setAttribute("aria-label", "Retry loading Strudel player");
+  retry.addEventListener("click", () => {
+    if (lastRenderArgs) {
+      renderPattern(lastRenderArgs);
+    }
+  });
+  box.appendChild(retry);
+
+  container.appendChild(box);
+}
+
 async function renderPattern(args: Record<string, unknown>) {
   const code = args.code as string | undefined;
   if (!code) return;
 
+  lastRenderArgs = args;
   const bpm = args.bpm as number | undefined;
   const autoplay = args.autoplay as boolean | undefined;
 
   try {
     setStatus("Loading Strudel...");
-    await loadStrudelCDN();
+    try {
+      await loadStrudelCDN();
+    } catch (cdnErr) {
+      setStatus("Failed to load Strudel — click Retry", "error");
+      showCdnError();
+      return;
+    }
 
     let finalCode = code;
     if (bpm) {
@@ -258,10 +340,12 @@ async function renderPattern(args: Record<string, unknown>) {
     }
     currentCode = finalCode;
 
-    // Create <strudel-editor> with code in HTML comment format
+    // Create the <strudel-editor> element programmatically (no innerHTML sink).
+    // The code is loaded via the safe editor.setCode() API below.
     if (!editorEl) {
-      container.innerHTML = `<strudel-editor><!--\n${finalCode}\n--></strudel-editor>`;
-      editorEl = container.querySelector("strudel-editor");
+      const newEditor = document.createElement("strudel-editor");
+      container.replaceChildren(newEditor);
+      editorEl = newEditor;
     }
 
     setStatus("Initializing...");
@@ -278,15 +362,24 @@ async function renderPattern(args: Record<string, unknown>) {
     // Enable recording once pattern is loaded
     recordBtn.disabled = false;
 
+    // Surface a non-blocking warning if soundfont registration failed —
+    // explains silent/absent audio rather than swallowing it.
+    const soundfontNote = soundfontWarning
+      ? " (soundfonts unavailable — audio may be silent)"
+      : "";
+
     if (autoplay !== false) {
       try {
         editor.evaluate(finalCode, true);
         updatePlayState(true);
+        if (soundfontWarning) {
+          setStatus(`Playing...${soundfontNote}`, "playing");
+        }
       } catch {
-        setStatus("Click Play to start", "normal");
+        setStatus(`Click Play to start${soundfontNote}`, "normal");
       }
     } else {
-      setStatus("Ready — click Play or Ctrl+Enter", "normal");
+      setStatus(`Ready — click Play or Ctrl+Enter${soundfontNote}`, "normal");
     }
   } catch (err) {
     setStatus(`Error: ${(err as Error).message}`, "error");
@@ -326,24 +419,102 @@ downloadBtn.addEventListener("click", () => {
   handleDownload();
 });
 
+// Send the user's CURRENT (possibly edited) pattern back to the conversation.
+sendBtn.addEventListener("click", async () => {
+  const code = getLiveCode().trim();
+  if (!code) return;
+  sendBtn.disabled = true;
+  try {
+    await app.sendMessage({
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: "Here's my edited Strudel pattern:\n```\n" + code + "\n```",
+        },
+      ],
+    });
+  } catch (err) {
+    setStatus(`Send failed: ${(err as Error).message}`, "error");
+  } finally {
+    sendBtn.disabled = false;
+  }
+});
+
 // Fullscreen toggle
 fullscreenBtn.addEventListener("click", () => {
   app.requestDisplayMode({ mode: "fullscreen" });
 });
 
-// Connect to MCP ext-apps
-app.connect().then(() => {
-  app.ontoolinput = (params) => {
-    renderPattern(params.arguments ?? {});
-  };
+// =============================================================================
+// MCP ext-apps Integration
+// =============================================================================
 
-  app.ontoolinputpartial = (params) => {
-    const code = params.arguments?.code as string | undefined;
-    if (!code) return;
-    setStatus("Composing pattern...");
+// Register notification handlers BEFORE connect() — the SDK drops
+// notifications that have no handler registered at arrival time.
+app.ontoolinput = (params) => {
+  renderPattern(params.arguments ?? {});
+};
+
+app.ontoolinputpartial = (params) => {
+  const code = params.arguments?.code as string | undefined;
+  if (!code) return;
+  setStatus("Composing pattern...");
+  const editor = getEditor();
+  if (editor?.setCode) {
+    editor.setCode(code);
+  }
+};
+
+// Generation cancelled — clear the stuck "Composing pattern..." status
+// (mirrors the ABC widget).
+app.ontoolcancelled = (params) => {
+  const reason = params?.reason ? ` (${params.reason})` : "";
+  setStatus(`Generation cancelled${reason}.`, "normal");
+};
+
+// Stop all audio + recording and release the recording tap when the host
+// tears this instance down, so a discarded widget leaves nothing running.
+app.onteardown = () => {
+  try {
+    if (isRecording) stopRecording();
+    if (mediaRecorder?.state === "recording") mediaRecorder.stop();
+    mediaRecorder = null;
     const editor = getEditor();
-    if (editor?.setCode) {
-      editor.setCode(code);
+    editor?.stop?.();
+    updatePlayState(false);
+    // Disconnect ONLY the recording tap from the master output (not the
+    // speakers): masterGain.disconnect(dest) targets just our tap edge.
+    if (recordingMasterGain && recordingDest) {
+      try {
+        (recordingMasterGain as any).disconnect(recordingDest);
+      } catch { /* edge may already be gone */ }
     }
-  };
+    recordingMasterGain = null;
+    recordingDest = null;
+    recordingStream?.getTracks().forEach((t) => t.stop());
+    recordingStream = null;
+  } catch { /* best-effort cleanup */ }
+  return {};
+};
+
+app.onerror = console.error;
+
+// Connect, then read host capabilities and gate features accordingly.
+app.connect().then(() => {
+  const caps = app.getHostCapabilities();
+
+  // Download is host-mediated; if unsupported (e.g. mobile), hide the
+  // download/record flow so users don't hit a raw -32601 error.
+  canDownload = !!caps?.downloadFile;
+  if (!canDownload) {
+    downloadBtn.hidden = true;
+    recordBtn.hidden = true;
+    recordBtn.title = "Recording export not supported on this host";
+  }
+
+  // "Send to chat" needs the host to accept ui/message.
+  if (caps?.message) {
+    sendBtn.hidden = false;
+  }
 });

--- a/src/strudel-browser-fallback.ts
+++ b/src/strudel-browser-fallback.ts
@@ -3,7 +3,8 @@
 // In browser mode (not iframe sandbox), the full REPL renders correctly.
 // =============================================================================
 
-import { exec } from "node:child_process";
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
@@ -179,18 +180,18 @@ export async function openStrudelInBrowser(
   const dir = outputDir ?? path.join(os.homedir(), "Desktop", "mcp-music-studio");
   await fs.mkdir(dir, { recursive: true });
 
-  const filename = `strudel-${Date.now()}.html`;
+  const filename = `strudel-${randomUUID()}.html`;
   const filepath = path.join(dir, filename);
   await fs.writeFile(filepath, html, "utf-8");
 
-  const cmd =
-    process.platform === "darwin"
-      ? `open "${filepath}"`
-      : process.platform === "win32"
-        ? `start "" "${filepath}"`
-        : `xdg-open "${filepath}"`;
-
-  exec(cmd, () => {});
+  // Use execFile with an argv array so no shell parses the path.
+  const openErr = (err: Error | null) => {
+    if (err) console.error("Failed to open browser:", err.message);
+  };
+  if (process.platform === "darwin") execFile("open", [filepath], openErr);
+  else if (process.platform === "win32")
+    execFile("cmd", ["/c", "start", "", filepath], openErr);
+  else execFile("xdg-open", [filepath], openErr);
 
   return filepath;
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,2 @@
+// AUTO-GENERATED from package.json by scripts/sync-version.mjs — do not edit by hand.
+export const VERSION = "0.4.0";

--- a/strudel-app.html
+++ b/strudel-app.html
@@ -10,11 +10,12 @@
   <main class="main">
     <header class="header">
       <div class="toolbar">
-        <button id="play-btn" class="control-btn" title="Play">Play</button>
-        <button id="record-btn" class="control-btn" title="Record audio" disabled>Record</button>
-        <button id="download-btn" class="control-btn" title="Download recording" disabled>↓</button>
-        <button id="fullscreen-btn" class="control-btn" title="Toggle fullscreen">⛶</button>
-        <span id="status" class="status">Ready</span>
+        <button id="play-btn" class="control-btn" title="Play" aria-label="Play">Play</button>
+        <button id="record-btn" class="control-btn" title="Record audio" aria-label="Record audio" disabled>Record</button>
+        <button id="download-btn" class="control-btn" title="Download recording" aria-label="Download recording" disabled>↓</button>
+        <button id="send-btn" class="control-btn" title="Send current pattern to chat" aria-label="Send current pattern to chat" hidden>Send to chat</button>
+        <button id="fullscreen-btn" class="control-btn" title="Toggle fullscreen" aria-label="Toggle fullscreen">⛶</button>
+        <span id="status" class="status" role="status" aria-live="polite">Ready</span>
       </div>
     </header>
 

--- a/tests/browser-fallback.test.ts
+++ b/tests/browser-fallback.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { generatePlayerHtml } from "../src/browser-fallback";
+import { generateStrudelPlayerHtml } from "../src/strudel-browser-fallback";
+
+describe("generatePlayerHtml (ABC browser fallback)", () => {
+  const ABC = "X:1\nT:Fallback Tune\nK:C\nCDEF|";
+
+  it("returns a non-empty self-contained HTML document", () => {
+    const html = generatePlayerHtml({ abcNotation: ABC });
+    expect(typeof html).toBe("string");
+    expect(html.length).toBeGreaterThan(0);
+    expect(html).toContain("<!DOCTYPE html>");
+    expect(html.trimEnd().endsWith("</html>")).toBe(true);
+  });
+
+  it("references ABCJS (loads it from a CDN script tag)", () => {
+    const html = generatePlayerHtml({ abcNotation: ABC });
+    expect(html.toLowerCase()).toContain("abcjs");
+    // The fallback emits the abcjs CDN script.
+    expect(html).toContain("cdn.jsdelivr.net/npm/abcjs");
+  });
+
+  it("embeds the supplied ABC notation content", () => {
+    const html = generatePlayerHtml({ abcNotation: ABC });
+    // The note sequence survives into the rendered HTML (textarea + INIT JSON).
+    expect(html).toContain("CDEF|");
+    // The title is extracted from T: and shown (HTML-escaped where needed).
+    expect(html).toContain("Fallback Tune");
+  });
+
+  it("HTML-escapes ABC content so angle brackets can't break the markup", () => {
+    // A T: header with markup-significant characters must be escaped in output.
+    const tricky = 'X:1\nT:Tune <b>&"\nK:C\nCDEF|';
+    const html = generatePlayerHtml({ abcNotation: tricky });
+    // Raw, unescaped injection of the title must NOT appear.
+    expect(html).not.toContain("Tune <b>");
+    // Escaped forms are present instead.
+    expect(html).toContain("&lt;b&gt;");
+  });
+
+  it("bakes injected tempo into the embedded notation when tempo is given", () => {
+    const html = generatePlayerHtml({ abcNotation: ABC, tempo: 132 });
+    expect(html).toContain("Q:1/4=132");
+  });
+});
+
+describe("generateStrudelPlayerHtml (Strudel browser fallback)", () => {
+  const CODE = 'sound("bd hh")';
+
+  it("returns a non-empty self-contained HTML document", () => {
+    const html = generateStrudelPlayerHtml({ code: CODE });
+    expect(typeof html).toBe("string");
+    expect(html.length).toBeGreaterThan(0);
+    expect(html).toContain("<!DOCTYPE html>");
+    expect(html.trimEnd().endsWith("</html>")).toBe(true);
+  });
+
+  it("embeds the supplied code (HTML-escaped) inside the strudel editor", () => {
+    const html = generateStrudelPlayerHtml({ code: CODE });
+    expect(html).toContain("<strudel-editor");
+    // escapeHtml turns " into &quot;, so the escaped form is what appears.
+    expect(html).toContain("sound(&quot;bd hh&quot;)");
+    // The raw double-quoted form must NOT be embedded verbatim.
+    expect(html).not.toContain('sound("bd hh")');
+  });
+
+  it("loads the Strudel REPL from its CDN", () => {
+    const html = generateStrudelPlayerHtml({ code: CODE });
+    expect(html).toContain("@strudel/repl");
+  });
+
+  it("prepends setcps when a bpm is supplied", () => {
+    const html = generateStrudelPlayerHtml({ code: CODE, bpm: 120 });
+    expect(html).toContain("setcps(");
+  });
+});

--- a/tests/parse-client.test.ts
+++ b/tests/parse-client.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { parseClient } from "../src/shared/parse-client";
+
+describe("parseClient", () => {
+  it("classifies known clients", () => {
+    expect(parseClient("claude-user")).toBe("claude-ai");
+    expect(parseClient("Claude-AI/1.0")).toBe("claude-ai");
+    expect(parseClient("something claude.ai something")).toBe("claude-ai");
+    expect(parseClient("claude-code/1.2")).toBe("claude-code");
+    expect(parseClient("Cursor/0.4")).toBe("cursor");
+    expect(parseClient("node gemini-cli")).toBe("gemini");
+    expect(parseClient("Windsurf")).toBe("windsurf");
+    expect(parseClient("cline-bot")).toBe("cline");
+    expect(parseClient("smithery-runner")).toBe("smithery");
+    expect(parseClient("mcp-remote/0.1")).toBe("mcp-remote");
+  });
+
+  it("returns unknown for unrecognized or empty UA", () => {
+    expect(parseClient("")).toBe("unknown");
+    expect(parseClient("RandomBot/9")).toBe("unknown");
+  });
+
+  it("is case-insensitive", () => {
+    expect(parseClient("CURSOR")).toBe("cursor");
+    expect(parseClient("WINDSURF/2")).toBe("windsurf");
+  });
+});

--- a/tests/prompts.test.ts
+++ b/tests/prompts.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createServer } from "../server";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+describe("music prompts", () => {
+  let client: Client;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    const server = createServer();
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    client = new Client({ name: "test-client", version: "1.0.0" });
+    await Promise.all([
+      client.connect(clientTransport),
+      server.server.connect(serverTransport),
+    ]);
+    cleanup = async () => {
+      await client.close();
+      await server.close();
+    };
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  it("lists the three music prompts", async () => {
+    const res = await client.listPrompts();
+    const names = res.prompts.map((p) => p.name).sort();
+    expect(names).toEqual(["arrange-tune", "compose-beat", "harmonize-melody"]);
+  });
+
+  it("compose-beat scaffolds a play-live-pattern flow", async () => {
+    const res = await client.getPrompt({
+      name: "compose-beat",
+      arguments: { genre: "techno", mood: "dark" },
+    });
+    expect(res.messages).toHaveLength(1);
+    expect(res.messages[0]?.role).toBe("user");
+    const text = (res.messages[0]?.content as { type: string; text: string })
+      .text;
+    expect(text).toContain("techno");
+    expect(text).toContain("dark");
+    expect(text).toContain("play-live-pattern");
+    expect(text).toContain("get-strudel-guide");
+  });
+
+  it("harmonize-melody embeds the melody and targets play-sheet-music", async () => {
+    const res = await client.getPrompt({
+      name: "harmonize-melody",
+      arguments: { melody: "X:1\nK:C\nCDEF|", style: "jazz" },
+    });
+    const text = (res.messages[0]?.content as { type: string; text: string })
+      .text;
+    expect(text).toContain("play-sheet-music");
+    expect(text).toContain("jazz");
+    expect(text).toContain("CDEF");
+  });
+});

--- a/tests/render-mode.test.ts
+++ b/tests/render-mode.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createServer } from "../server";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+type ContentBlock = {
+  type: string;
+  resource?: { uri: string; mimeType: string; text: string };
+};
+
+describe("render modes", () => {
+  let client: Client;
+  let cleanup: () => Promise<void>;
+
+  async function connect(mode: "auto" | "html") {
+    const server = createServer({ defaultRenderMode: mode });
+    const [c, s] = InMemoryTransport.createLinkedPair();
+    client = new Client({ name: "test-client", version: "1.0.0" });
+    await Promise.all([client.connect(c), server.server.connect(s)]);
+    cleanup = async () => {
+      await client.close();
+      await server.close();
+    };
+  }
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  it("html mode embeds an HTML resource block with the player", async () => {
+    await connect("html");
+    const res = await client.callTool({
+      name: "play-sheet-music",
+      arguments: { abcNotation: "X:1\nK:C\nCDEF|" },
+    });
+    const content = res.content as ContentBlock[];
+    const resourceBlock = content.find((c) => c.type === "resource");
+    expect(resourceBlock).toBeTruthy();
+    expect(resourceBlock?.resource?.uri).toContain("music://player/");
+    expect(resourceBlock?.resource?.mimeType).toBe("text/html");
+    expect(resourceBlock?.resource?.text).toContain("abcjs");
+  });
+
+  it("auto mode returns only text (UI rendered via _meta resource, not inline)", async () => {
+    await connect("auto");
+    const res = await client.callTool({
+      name: "play-sheet-music",
+      arguments: { abcNotation: "X:1\nK:C\nCDEF|" },
+    });
+    const content = res.content as ContentBlock[];
+    expect(content.every((c) => c.type === "text")).toBe(true);
+  });
+});

--- a/tests/search-docs-core.test.ts
+++ b/tests/search-docs-core.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  searchMusicDocs,
+  SEARCH_DOCS_MAX_CHARS,
+  SEARCH_DOCS_MAX_QUERY,
+} from "../src/shared/tool-defs";
+
+// Direct unit tests of the shared searchMusicDocs core (cache adapter + apiKey
+// injected per transport). The existing search-docs.test.ts only covers the
+// local server path (no cache, empty key); these cover the worker-shaped branches.
+
+afterEach(() => vi.restoreAllMocks());
+
+function textOf(result: { content: Array<{ type: string; text?: string }> }) {
+  return result.content[0]?.text ?? "";
+}
+
+describe("searchMusicDocs (shared core)", () => {
+  it("returns the cached value without fetching when cacheGet hits", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const result = await searchMusicDocs("anything", "strudel", {
+      cacheGet: async () => "CACHED DOCS",
+    });
+    expect(textOf(result)).toBe("CACHED DOCS");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("retries once with Bearer auth on HTTP 429 when a ctx7sk key is present", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("rate limited", { status: 429 }))
+      .mockResolvedValueOnce(new Response("AUTHED DOCS", { status: 200 }));
+
+    const result = await searchMusicDocs("fm synthesis", "strudel", {
+      apiKey: "ctx7sk-secret",
+    });
+
+    expect(textOf(result)).toContain("AUTHED DOCS");
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const secondCallInit = fetchSpy.mock.calls[1]?.[1] as RequestInit | undefined;
+    expect((secondCallInit?.headers as Record<string, string>)?.Authorization).toBe(
+      "Bearer ctx7sk-secret",
+    );
+  });
+
+  it("does NOT retry on 429 without a valid key (errors with the status)", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("rate limited", { status: 429 }));
+
+    const result = await searchMusicDocs("x", "strudel", {});
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain("429");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("truncates oversized payloads and appends a truncation marker", async () => {
+    const big = "a".repeat(SEARCH_DOCS_MAX_CHARS + 5000);
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(big, { status: 200 }),
+    );
+    const result = await searchMusicDocs("big", "strudel", {});
+    const text = textOf(result);
+    expect(text.length).toBeLessThan(big.length);
+    expect(text).toContain("results truncated");
+  });
+
+  it("caps the query at SEARCH_DOCS_MAX_QUERY code points before use", async () => {
+    const cacheGet = vi.fn(async () => null);
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("docs", { status: 200 }),
+    );
+    const longQuery = "q".repeat(SEARCH_DOCS_MAX_QUERY + 100);
+    await searchMusicDocs(longQuery, "strudel", { cacheGet });
+    const key = cacheGet.mock.calls[0]?.[0] as string;
+    // key = `ctx7:strudel:<q>` where q is capped to SEARCH_DOCS_MAX_QUERY
+    expect(key.length).toBe("ctx7:strudel:".length + SEARCH_DOCS_MAX_QUERY);
+  });
+
+  it("writes successful results to the cache adapter", async () => {
+    const cachePut = vi.fn(async () => {});
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("fresh docs", { status: 200 }),
+    );
+    await searchMusicDocs("note function", "abcjs", { cachePut });
+    expect(cachePut).toHaveBeenCalledTimes(1);
+    expect(cachePut.mock.calls[0]?.[1]).toContain("fresh docs");
+  });
+});

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -37,4 +37,20 @@ describe("play-sheet-music handler", () => {
       "Expected note after bar line",
     );
   });
+
+  it("clean parse returns honest text and does not claim playback", async () => {
+    const parseOnly: ParseOnlyFn = () => [{}];
+
+    const result = await handlePlaySheetMusic(
+      { abcNotation: "X:1\nK:C\nCDEF|" },
+      parseOnly,
+    );
+
+    expect(result.isError).toBeUndefined();
+    const text = result.content[0]?.text ?? "";
+    // Honest: tells the agent nothing played if there's no widget...
+    expect(text).toContain("nothing has played yet");
+    // ...and never asserts it played.
+    expect(text).not.toMatch(/playing!|successfully played|now playing/i);
+  });
 });

--- a/tests/strudel.test.ts
+++ b/tests/strudel.test.ts
@@ -16,7 +16,7 @@ describe("play-live-pattern handler", () => {
     expect(result.content).toHaveLength(1);
     expect(result.content[0]?.type).toBe("text");
     expect(result.content[0]?.text).toContain('"Test Beat"');
-    expect(result.content[0]?.text).toContain("Strudel pattern playing");
+    expect(result.content[0]?.text).toContain("Strudel pattern ready");
   });
 
   it("returns text result without title", async () => {
@@ -24,7 +24,11 @@ describe("play-live-pattern handler", () => {
       code: 's("bd sd")',
     });
 
-    expect(result.content[0]?.text).toBe("Strudel pattern playing.");
+    expect(result.content[0]?.text).toBe(
+      "Strudel pattern ready. It plays in an editable REPL widget in MCP-app hosts " +
+        "(e.g. Claude Desktop, claude.ai). If you don't see a player here, this client can't play it " +
+        "inline, so nothing has played yet.",
+    );
     expect(result.content[0]?.text).not.toContain('"');
   });
 });

--- a/tests/version.test.ts
+++ b/tests/version.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { VERSION } from "../src/version";
+
+// Guards the version single-source-of-truth: src/version.ts is generated from
+// package.json by scripts/sync-version.mjs at build. A mismatch here means the
+// generated file is stale (e.g. a deploy/publish without a prior `bun run build`).
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
+
+describe("version single source of truth", () => {
+  it("src/version.ts VERSION matches package.json version", () => {
+    expect(VERSION).toBe(pkg.version);
+  });
+});

--- a/tests/wav-encoder.test.ts
+++ b/tests/wav-encoder.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { audioBufferToWavBase64 } from "../src/wav-encoder";
+
+// Minimal AudioBuffer-shaped stub matching exactly what audioBufferToWavBase64
+// reads: numberOfChannels, sampleRate, length, getChannelData(ch).
+function makeStubBuffer(
+  channels: Float32Array[],
+  sampleRate: number,
+): AudioBuffer {
+  const length = channels[0]?.length ?? 0;
+  const stub = {
+    numberOfChannels: channels.length,
+    sampleRate,
+    length,
+    getChannelData(ch: number): Float32Array {
+      return channels[ch];
+    },
+  };
+  // The encoder only touches the four members above.
+  return stub as unknown as AudioBuffer;
+}
+
+function decode(b64: string): Buffer {
+  return Buffer.from(b64, "base64");
+}
+
+const SAMPLE_RATE = 44100;
+
+describe("audioBufferToWavBase64", () => {
+  it("produces a canonical 44-byte WAV header (mono)", () => {
+    // length 4, includes a negative and a positive sample for clamping path.
+    const ch0 = new Float32Array([0, 0.5, -0.5, 1]);
+    const buf = makeStubBuffer([ch0], SAMPLE_RATE);
+
+    const bytes = decode(audioBufferToWavBase64(buf));
+
+    const numCh = 1;
+    const dataSize = ch0.length * numCh * 2; // length * channels * bytesPerSample
+
+    // RIFF / WAVE / fmt  / data chunk identifiers
+    expect(bytes.toString("ascii", 0, 4)).toBe("RIFF");
+    expect(bytes.toString("ascii", 8, 12)).toBe("WAVE");
+    expect(bytes.toString("ascii", 12, 16)).toBe("fmt ");
+    expect(bytes.toString("ascii", 36, 40)).toBe("data");
+
+    // fmt chunk fields (little-endian)
+    expect(bytes.readUInt16LE(20)).toBe(1); // audio format = PCM
+    expect(bytes.readUInt16LE(22)).toBe(numCh); // num channels
+    expect(bytes.readUInt32LE(24)).toBe(SAMPLE_RATE); // sample rate
+    expect(bytes.readUInt16LE(34)).toBe(16); // bits per sample
+
+    // data size + RIFF chunk size + total byte length
+    expect(bytes.readUInt32LE(40)).toBe(dataSize);
+    expect(bytes.readUInt32LE(4)).toBe(36 + dataSize);
+    expect(bytes.length).toBe(44 + dataSize);
+  });
+
+  it("encodes stereo with interleaved 16-bit samples and correct sizes", () => {
+    const left = new Float32Array([0, 1, -1, 0.25]);
+    const right = new Float32Array([-1, 0, 0.75, -0.25]);
+    const buf = makeStubBuffer([left, right], SAMPLE_RATE);
+
+    const bytes = decode(audioBufferToWavBase64(buf));
+
+    const numCh = 2;
+    const dataSize = left.length * numCh * 2;
+
+    expect(bytes.readUInt16LE(22)).toBe(numCh);
+    expect(bytes.readUInt32LE(40)).toBe(dataSize);
+    expect(bytes.length).toBe(44 + dataSize);
+    // byte rate = sampleRate * numCh * bytesPerSample
+    expect(bytes.readUInt32LE(28)).toBe(SAMPLE_RATE * numCh * 2);
+    // block align = numCh * bytesPerSample
+    expect(bytes.readUInt16LE(32)).toBe(numCh * 2);
+
+    // First interleaved frame: left[0]=0 -> 0, right[0]=-1 -> -32768 (0x8000).
+    expect(bytes.readInt16LE(44)).toBe(0); // left[0]
+    expect(bytes.readInt16LE(46)).toBe(-32768); // right[0], full-scale negative
+  });
+
+  it("clamps and scales boundary samples (16-bit PCM)", () => {
+    // +1 -> 0x7fff (32767), -1 -> -0x8000 (-32768); out-of-range clamps.
+    const ch0 = new Float32Array([1, -1, 2, -2]);
+    const buf = makeStubBuffer([ch0], SAMPLE_RATE);
+
+    const bytes = decode(audioBufferToWavBase64(buf));
+
+    expect(bytes.readInt16LE(44)).toBe(32767); // +1 => 0x7fff
+    expect(bytes.readInt16LE(46)).toBe(-32768); // -1 => -0x8000
+    expect(bytes.readInt16LE(48)).toBe(32767); // +2 clamps to +1 => 0x7fff
+    expect(bytes.readInt16LE(50)).toBe(-32768); // -2 clamps to -1 => -0x8000
+  });
+});

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -4,6 +4,10 @@
 // Remote MCP server for one-paste setup. Stateless handler (new server per
 // request) using createMcpHandler + WorkerTransport — matches the official
 // ext-apps example pattern for reliable UI rendering in Claude Desktop.
+//
+// Tool names, schemas, descriptions, annotations, _meta, instructions, and the
+// search-music-docs behavior are imported from ../../src/shared/tool-defs so
+// they never drift from the local stdio/HTTP server (server.ts).
 // =============================================================================
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -11,16 +15,37 @@ import { createMcpHandler } from "agents/mcp";
 import { z } from "zod";
 
 // Shared guide content (pure data, no Node.js deps)
+import { ABC_GUIDE_TOPICS, ABC_GUIDES } from "../../src/abc-guide.js";
+import { STRUDEL_GUIDE_TOPICS, STRUDEL_GUIDES } from "../../src/strudel-guide.js";
+import { VERSION } from "../../src/version.js";
+import { parseClient } from "../../src/shared/parse-client.js";
 import {
-  ABC_GUIDE_TOPICS,
-  ABC_GUIDES,
-  DEFAULT_ABC_NOTATION,
-} from "../../src/abc-guide.js";
-import {
-  STRUDEL_GUIDE_TOPICS,
-  STRUDEL_GUIDES,
-} from "../../src/strudel-guide.js";
-import { STYLE_NAMES } from "../../src/music-logic.js";
+  SHEET_RESOURCE_URI,
+  STRUDEL_RESOURCE_URI,
+  SERVER_INSTRUCTIONS,
+  advertiseUiExtension,
+  PLAY_TOOL_ANNOTATIONS,
+  GUIDE_TOOL_ANNOTATIONS,
+  SEARCH_TOOL_ANNOTATIONS,
+  SHEET_CSP,
+  STRUDEL_CSP,
+  PLAY_SHEET_BASE_DESCRIPTION,
+  PLAY_SHEET_EXT_APPS_SUFFIX,
+  PLAY_SHEET_NEUTRAL_TEXT,
+  playSheetInputSchema,
+  PLAY_LIVE_BASE_DESCRIPTION,
+  PLAY_LIVE_EXT_APPS_SUFFIX,
+  playLiveInputSchema,
+  buildPlayLiveResult,
+  GET_MUSIC_GUIDE_DESCRIPTION,
+  GET_MUSIC_GUIDE_TOPIC_DESCRIPTION,
+  GET_STRUDEL_GUIDE_DESCRIPTION,
+  GET_STRUDEL_GUIDE_TOPIC_DESCRIPTION,
+  SEARCH_DOCS_DESCRIPTION,
+  searchDocsInputSchema,
+  searchMusicDocs,
+  registerMusicPrompts,
+} from "../../src/shared/tool-defs.js";
 
 // Bundled ext-apps HTML (wrangler imports as text via rules config)
 import sheetMusicHtml from "../../dist/mcp-app.html";
@@ -49,34 +74,18 @@ function track(
   } catch {}
 }
 
-function parseClient(ua: string): string {
-  const lower = ua.toLowerCase();
-  if (lower === "claude-user") return "claude-ai";
-  if (lower.includes("claude-ai") || lower.includes("claude.ai"))
-    return "claude-ai";
-  if (lower.includes("claude-code") || lower.includes("claude code"))
-    return "claude-code";
-  if (lower.includes("cursor")) return "cursor";
-  if (lower.includes("gemini")) return "gemini";
-  if (lower.includes("windsurf")) return "windsurf";
-  if (lower.includes("cline")) return "cline";
-  if (lower.includes("smithery")) return "smithery";
-  if (lower.includes("mcp-remote")) return "mcp-remote";
-  return "unknown";
-}
-
-function trackRequest(
-  env: Env,
-  ctx: ExecutionContext,
-  request: Request,
-) {
+function trackRequest(env: Env, ctx: ExecutionContext, request: Request) {
   const rawUA = request.headers.get("user-agent") ?? "";
   const client = parseClient(rawUA);
-  const truncUA = rawUA.substring(0, 200);
+  // Only retain the raw UA for clients we don't recognize (to discover new ones);
+  // the coarse `client` label already covers known clients. Data minimization.
+  const uaForLog = client === "unknown" ? rawUA.substring(0, 200) : "";
 
   if (request.method === "GET") {
+    // A bare GET /mcp is not a real session in stateless mode (it 406s) — label
+    // it "probe" so it isn't conflated with POST-initiated sessions.
     track(env, {
-      blobs: ["session", "", "", truncUA],
+      blobs: ["probe", "", "", uaForLog],
       indexes: [client],
     });
     return;
@@ -91,7 +100,6 @@ function trackRequest(
       .then((body: any) => {
         const method = body?.method ?? "unknown";
 
-        // Track all JSON-RPC methods for debugging ext-apps lifecycle
         if (method === "tools/call") {
           const tool = body.params?.name ?? "";
           const args = body.params?.arguments ?? {};
@@ -102,19 +110,19 @@ function trackRequest(
             detail = args.library ?? "strudel";
           }
           track(env, {
-            blobs: ["tool_call", tool, detail, truncUA],
+            blobs: ["tool_call", tool, detail, uaForLog],
             indexes: [client],
           });
         } else if (method === "resources/read") {
           const uri = body.params?.uri ?? "";
           track(env, {
-            blobs: ["resource_read", uri, "", truncUA],
+            blobs: ["resource_read", uri, "", uaForLog],
             indexes: [client],
           });
         } else {
           // initialize, tools/list, resources/list, etc.
           track(env, {
-            blobs: ["mcp_method", method, "", truncUA],
+            blobs: ["mcp_method", method, "", uaForLog],
             indexes: [client],
           });
         }
@@ -128,25 +136,22 @@ function trackRequest(
 // =============================================================================
 
 const EXT_APPS_MIME = "text/html;profile=mcp-app" as const;
-const SHEET_RESOURCE_URI = "ui://sheet-music/mcp-app.html";
-const STRUDEL_RESOURCE_URI = "ui://strudel/strudel-app.html";
 
 // =============================================================================
 // Server factory — creates a fresh McpServer per request (stateless)
 // =============================================================================
 
 function createMusicServer(env: Env): McpServer {
-  const server = new McpServer({
-    name: "Music Studio",
-    version: "0.3.0",
-  });
+  const server = new McpServer(
+    { name: "Music Studio", version: VERSION },
+    { instructions: SERVER_INSTRUCTIONS },
+  );
 
   // Advertise ext-apps support so clients know to render UI widgets
-  server.server.registerCapabilities({
-    extensions: {
-      "io.modelcontextprotocol/ui": {},
-    },
-  });
+  advertiseUiExtension(server.server);
+
+  // Slash-command prompts: compose-beat, harmonize-melody, arrange-tune.
+  registerMusicPrompts(server);
 
   // ===========================================================================
   // Ext-Apps UI Resources
@@ -162,13 +167,7 @@ function createMusicServer(env: Env): McpServer {
           uri: SHEET_RESOURCE_URI,
           mimeType: EXT_APPS_MIME,
           text: sheetMusicHtml,
-          _meta: {
-            ui: {
-              csp: {
-                connectDomains: ["https://paulrosen.github.io"],
-              },
-            },
-          },
+          _meta: { ui: { csp: { ...SHEET_CSP } } },
         },
       ],
     }),
@@ -184,123 +183,64 @@ function createMusicServer(env: Env): McpServer {
           uri: STRUDEL_RESOURCE_URI,
           mimeType: EXT_APPS_MIME,
           text: strudelHtml,
-          _meta: {
-            ui: {
-              csp: {
-                resourceDomains: [
-                  "https://unpkg.com",
-                  "https://cdn.jsdelivr.net",
-                ],
-                connectDomains: [
-                  "https://unpkg.com",
-                  "https://raw.githubusercontent.com",
-                  "https://cdn.jsdelivr.net",
-                  "https://felixroos.github.io",
-                  "https://tidalcycles.github.io",
-                ],
-              },
-            },
-          },
+          _meta: { ui: { csp: { ...STRUDEL_CSP } } },
         },
       ],
     }),
   );
 
   // ===========================================================================
-  // Tool: play-sheet-music (registerTool for _meta support)
+  // Tool: play-sheet-music
   // ===========================================================================
-
+  // Note: ABC is parsed/rendered client-side in the widget, so the worker does
+  // not assert a parse result here — neutral wording avoids a false success.
   server.registerTool(
     "play-sheet-music",
     {
       title: "Play Sheet Music",
-      description:
-        "Compose and play sheet music with visual notation, multi-instrument audio, " +
-        "and style presets. Write ABC notation for melodies, arrangements, harmonized " +
-        "pieces, or well-known tunes. Add a style (rock, jazz, bossa, waltz, folk...) " +
-        "for automatic drums, bass, and chord accompaniment. " +
-        "Use get-music-guide for genre templates, instrument lists, and ABC syntax reference." +
-        "\n\nThe music player renders inline with interactive playback controls.",
-      inputSchema: z.object({
-        abcNotation: z
-          .string()
-          .default(DEFAULT_ABC_NOTATION)
-          .describe(
-            'ABC notation string. Include chord symbols ("C", "Am7") above notes for auto-accompaniment with style presets.',
-          ),
-        title: z
-          .string()
-          .optional()
-          .describe(
-            "Piece title (overrides T: in ABC). Displayed in the widget header.",
-          ),
-        instrument: z
-          .string()
-          .optional()
-          .describe(
-            "Default instrument (e.g. 'Flute', 'Cello', 'Acoustic Grand Piano', 'Alto Sax'). " +
-              "Use get-music-guide with topic 'instruments' for the full list.",
-          ),
-        style: z
-          .enum(STYLE_NAMES)
-          .optional()
-          .describe(
-            "Accompaniment style. Adds drums, bass, and chord patterns automatically. " +
-              'Your ABC needs chord symbols ("C", "Am") for accompaniment to work. ' +
-              "Options: rock, jazz, bossa, waltz, march, reggae, folk, classical.",
-          ),
-        tempo: z
-          .number()
-          .min(40)
-          .max(240)
-          .optional()
-          .describe("Tempo in BPM (40-240). Overrides Q: in ABC notation."),
-        swing: z
-          .number()
-          .min(0)
-          .max(100)
-          .optional()
-          .describe(
-            "Swing percentage (0-100). 0=straight, 33=light swing, 66=heavy swing. Great for jazz and blues.",
-          ),
-        transpose: z
-          .number()
-          .min(-12)
-          .max(12)
-          .optional()
-          .describe(
-            "Transpose by semitones (-12 to 12). Positive=higher, negative=lower.",
-          ),
-      }),
+      description: PLAY_SHEET_BASE_DESCRIPTION + PLAY_SHEET_EXT_APPS_SUFFIX,
+      inputSchema: playSheetInputSchema,
+      annotations: PLAY_TOOL_ANNOTATIONS,
       _meta: {
         ui: { resourceUri: SHEET_RESOURCE_URI },
         "ui/resourceUri": SHEET_RESOURCE_URI,
       },
     },
     async () => ({
-      content: [
-        { type: "text" as const, text: "Music parsed successfully. Playing!" },
-      ],
+      content: [{ type: "text" as const, text: PLAY_SHEET_NEUTRAL_TEXT }],
     }),
+  );
+
+  // ===========================================================================
+  // Tool: play-live-pattern
+  // ===========================================================================
+  server.registerTool(
+    "play-live-pattern",
+    {
+      title: "Play Live Pattern",
+      description: PLAY_LIVE_BASE_DESCRIPTION + PLAY_LIVE_EXT_APPS_SUFFIX,
+      inputSchema: playLiveInputSchema,
+      annotations: PLAY_TOOL_ANNOTATIONS,
+      _meta: {
+        ui: { resourceUri: STRUDEL_RESOURCE_URI },
+        "ui/resourceUri": STRUDEL_RESOURCE_URI,
+      },
+    },
+    async (args) => buildPlayLiveResult(args),
   );
 
   // ===========================================================================
   // Tool: get-music-guide
   // ===========================================================================
-
-  server.tool(
+  server.registerTool(
     "get-music-guide",
-    "Returns detailed reference material for music composition. " +
-      "Topics: instruments (GM instrument list + combos), drums (patterns + percussion notes), " +
-      "abc-syntax (notation reference), arrangements (multi-voice patterns), " +
-      "genres (complete ABC templates for jazz/blues/folk/rock/bossa/classical), " +
-      "styles (what each style preset does), midi-directives (%%MIDI reference).",
     {
-      topic: z
-        .enum(ABC_GUIDE_TOPICS)
-        .describe(
-          "Reference topic. Start with 'genres' for complete examples, 'styles' to understand presets, or 'instruments' for the full instrument list.",
-        ),
+      title: "Music Reference Guide",
+      description: GET_MUSIC_GUIDE_DESCRIPTION,
+      inputSchema: z.object({
+        topic: z.enum(ABC_GUIDE_TOPICS).describe(GET_MUSIC_GUIDE_TOPIC_DESCRIPTION),
+      }),
+      annotations: GUIDE_TOOL_ANNOTATIONS,
     },
     async ({ topic }) => ({
       content: [{ type: "text" as const, text: ABC_GUIDES[topic] }],
@@ -308,86 +248,19 @@ function createMusicServer(env: Env): McpServer {
   );
 
   // ===========================================================================
-  // Tool: play-live-pattern (registerTool for _meta support)
-  // ===========================================================================
-
-  server.registerTool(
-    "play-live-pattern",
-    {
-      title: "Play Live Pattern",
-      description:
-        "Live-code music patterns using TidalCycles mini-notation in JavaScript. " +
-        "Layer drums, synths, and bass with stack(). Choose from 72 drum machine banks, " +
-        "128 GM instruments, built-in synths, and a full effects chain. " +
-        "Patterns play in a REPL the user can edit directly. " +
-        "Use get-strudel-guide for genre templates, sound references, and advanced features " +
-        "like visualization, arrangement, and sample loading." +
-        "\n\nThe Strudel REPL renders inline with an editable code editor, " +
-        "visualizations, and playback controls.",
-      inputSchema: z.object({
-        code: z
-          .string()
-          .describe(
-            "Strudel pattern code. Uses TidalCycles mini-notation in JavaScript. " +
-              "Use stack() to layer drums, bass, and melody. " +
-              "Set tempo with setcps(bpm/60/4) or use the bpm parameter.",
-          ),
-        title: z
-          .string()
-          .optional()
-          .describe(
-            "Pattern title displayed in the widget header (e.g. 'Midnight Rain').",
-          ),
-        bpm: z
-          .number()
-          .min(40)
-          .max(300)
-          .optional()
-          .describe(
-            "Tempo in BPM (40-300). Converts to setcps() automatically.",
-          ),
-        autoplay: z
-          .boolean()
-          .optional()
-          .describe(
-            "Start playing immediately (default: true). May require user click due to browser autoplay policy.",
-          ),
-      }),
-      _meta: {
-        ui: { resourceUri: STRUDEL_RESOURCE_URI },
-        "ui/resourceUri": STRUDEL_RESOURCE_URI,
-      },
-    },
-    async (args) => {
-      const label = args.title ? `"${args.title}" — ` : "";
-      return {
-        content: [
-          { type: "text" as const, text: `${label}Strudel pattern playing.` },
-        ],
-      };
-    },
-  );
-
-  // ===========================================================================
   // Tool: get-strudel-guide
   // ===========================================================================
-
-  server.tool(
+  server.registerTool(
     "get-strudel-guide",
-    "Reference material for Strudel live coding (performance mode). " +
-      "Topics: mini-notation (pattern syntax), sounds (synths, 72 drum banks, 128 GM instruments), " +
-      "effects (filters, reverb, delay, FM synthesis, envelopes), " +
-      "patterns (transformations, probability, euclidean, arrangement), " +
-      "genres (complete templates: techno/house/dnb/ambient/jazz/lofi/synthwave), " +
-      "tips (tempo, common mistakes, ABC↔Strudel crossover), " +
-      "advanced (visualization, sample loading, wavetables, ZZFX, continuous signals, chord voicings).",
     {
-      topic: z
-        .enum(STRUDEL_GUIDE_TOPICS)
-        .describe(
-          "Reference topic. Start with 'genres' for working templates, " +
-            "'sounds' for instruments, 'advanced' for visualization and sample loading.",
-        ),
+      title: "Strudel Reference Guide",
+      description: GET_STRUDEL_GUIDE_DESCRIPTION,
+      inputSchema: z.object({
+        topic: z
+          .enum(STRUDEL_GUIDE_TOPICS)
+          .describe(GET_STRUDEL_GUIDE_TOPIC_DESCRIPTION),
+      }),
+      annotations: GUIDE_TOOL_ANNOTATIONS,
     },
     async ({ topic }) => ({
       content: [{ type: "text" as const, text: STRUDEL_GUIDES[topic] }],
@@ -395,100 +268,23 @@ function createMusicServer(env: Env): McpServer {
   );
 
   // ===========================================================================
-  // Tool: search-music-docs (Context7-powered semantic search)
+  // Tool: search-music-docs (Context7-powered, KV-cached)
   // ===========================================================================
-
-  server.tool(
+  server.registerTool(
     "search-music-docs",
-    "Search detailed documentation for Strudel live coding or ABC/ABCJS notation. " +
-      "Returns relevant code examples and explanations from the official docs. " +
-      "Use this when the curated guides (get-strudel-guide, get-music-guide) don't " +
-      "cover what you need — for specific functions, advanced techniques, or when " +
-      "you're unsure about syntax. Powered by semantic search over strudel.cc and ABCJS docs.",
     {
-      query: z
-        .string()
-        .describe(
-          "What you want to know. Be specific. " +
-            "Good: 'how to use FM synthesis with envelope' or 'chop and slice sample manipulation'. " +
-            "Bad: 'effects' or 'help'.",
-        ),
-      library: z
-        .enum(["strudel", "abcjs"])
-        .default("strudel")
-        .describe(
-          "Which library to search: 'strudel' for live coding patterns, 'abcjs' for sheet music notation.",
-        ),
+      title: "Search Music Documentation",
+      description: SEARCH_DOCS_DESCRIPTION,
+      inputSchema: searchDocsInputSchema,
+      annotations: SEARCH_TOOL_ANNOTATIONS,
     },
-    async ({ query, library }) => {
-      const libraryId =
-        library === "strudel"
-          ? "/websites/strudel_cc"
-          : "/paulrosen/abcjs";
-
-      // Check KV cache first
-      const cacheKey = `ctx7:${library}:${query}`;
-      try {
-        const cached = await env.DOCS_CACHE.get(cacheKey);
-        if (cached) {
-          return { content: [{ type: "text" as const, text: cached }] };
-        }
-      } catch {}
-
-      const params = new URLSearchParams({ libraryId, query, type: "txt" });
-      const url = `https://context7.com/api/v2/context?${params}`;
-      const apiKey = env.CONTEXT7_API_KEY ?? "";
-
-      try {
-        let res = await fetch(url);
-        if (res.status === 429 && apiKey && apiKey.startsWith("ctx7sk")) {
-          res = await fetch(url, {
-            headers: { Authorization: `Bearer ${apiKey}` },
-          });
-        }
-
-        if (!res.ok) {
-          const errText = await res.text().catch(() => "");
-          return {
-            isError: true,
-            content: [
-              {
-                type: "text" as const,
-                text: `Documentation search failed (${res.status}). ${errText}\n\nTry the curated guides instead.`,
-              },
-            ],
-          };
-        }
-
-        const text = await res.text();
-        if (!text || text.trim().length === 0) {
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text: `No results found for "${query}" in ${library} docs. Try rephrasing or use the curated guides.`,
-              },
-            ],
-          };
-        }
-
-        try {
-          await env.DOCS_CACHE.put(cacheKey, text, { expirationTtl: 86400 });
-        } catch {}
-
-        return { content: [{ type: "text" as const, text }] };
-      } catch (err) {
-        return {
-          isError: true,
-          content: [
-            {
-              type: "text" as const,
-              text: `Documentation search error: ${(err as Error).message}\n\nUse get-strudel-guide or get-music-guide as fallback.`,
-            },
-          ],
-        };
-      }
-    },
+    async ({ query, library }) =>
+      searchMusicDocs(query, library, {
+        apiKey: env.CONTEXT7_API_KEY,
+        cacheGet: (key) => env.DOCS_CACHE.get(key),
+        cachePut: (key, value) =>
+          env.DOCS_CACHE.put(key, value, { expirationTtl: 86400 }),
+      }),
   );
 
   // ===========================================================================
@@ -502,9 +298,7 @@ function createMusicServer(env: Env): McpServer {
       uri,
       { mimeType: "text/plain", description: `Music reference: ${topic}` },
       async () => ({
-        contents: [
-          { uri, mimeType: "text/plain" as const, text: ABC_GUIDES[topic] },
-        ],
+        contents: [{ uri, mimeType: "text/plain" as const, text: ABC_GUIDES[topic] }],
       }),
     );
   }
@@ -516,13 +310,7 @@ function createMusicServer(env: Env): McpServer {
       uri,
       { mimeType: "text/plain", description: `Strudel reference: ${topic}` },
       async () => ({
-        contents: [
-          {
-            uri,
-            mimeType: "text/plain" as const,
-            text: STRUDEL_GUIDES[topic],
-          },
-        ],
+        contents: [{ uri, mimeType: "text/plain" as const, text: STRUDEL_GUIDES[topic] }],
       }),
     );
   }
@@ -538,6 +326,13 @@ export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext) {
     const url = new URL(request.url);
 
+    // Lightweight liveness probe — keeps uptime checks off the MCP transport.
+    if (url.pathname === "/health" || url.pathname === "/healthz") {
+      return new Response(JSON.stringify({ status: "ok", version: VERSION }), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+
     if (url.pathname === "/mcp" || url.pathname === "/mcp/") {
       trackRequest(env, ctx, request);
 
@@ -546,11 +341,16 @@ export default {
       // ext-apps UI — the default SSE response format isn't parsed correctly
       // by the Connector client for resources/read calls.
       const server = createMusicServer(env);
-      const handler = createMcpHandler(server, {
-        route: null as unknown as string,
-        sessionIdGenerator: undefined,
-        enableJsonResponse: true,
-      });
+      // `agents` bundles its own @modelcontextprotocol/sdk copy, so its McpServer
+      // type is nominally distinct from ours (separate private fields). Safe at runtime.
+      const handler = createMcpHandler(
+        server as unknown as Parameters<typeof createMcpHandler>[0],
+        {
+          route: null as unknown as string,
+          sessionIdGenerator: undefined,
+          enableJsonResponse: true,
+        },
+      );
       return handler(request, env, ctx);
     }
 
@@ -559,7 +359,8 @@ export default {
       return new Response(null, {
         status: 301,
         headers: {
-          Location: "https://raw.githubusercontent.com/linxule/mcp-music-studio/main/assets/logo.png",
+          Location:
+            "https://raw.githubusercontent.com/linxule/mcp-music-studio/main/assets/logo.png",
           "cache-control": "public, max-age=604800",
         },
       });
@@ -574,7 +375,7 @@ export default {
 <title>MCP Music Studio</title>
 <link rel="icon" type="image/png" href="/favicon.png">
 </head><body style="font-family:system-ui;max-width:520px;margin:40px auto;color:#333">
-<h1>MCP Music Studio v0.3.0</h1>
+<h1>MCP Music Studio v${VERSION}</h1>
 <p>Two-mode creative music studio: scored composition (ABC notation) and live performance (Strudel live coding).</p>
 <h3>Connect</h3>
 <ul>


### PR DESCRIPTION
## What

Audit-driven v0.4.0. A grounded 60-agent MCP best-practice audit (52 findings → 49 verified) followed by a 4-phase refactor, then a final 7-dimension multi-agent team review.

## Highlights
- **Single source of truth** `src/shared/tool-defs.ts` consumed by both transports (local `server.ts` + Cloudflare `worker/`) — eliminates the local/remote drift that was the audit's master theme.
- **Removed dead `oninitialized`** description-upgrade (threw "already registered", swallowed; couldn't fire before `tools/list` in stateless HTTP). Descriptions are now deterministic per render mode.
- **Version single-source**: `src/version.ts` generated from `package.json` by `scripts/sync-version.mjs`; CI tag/version guard + a consistency test.
- **3 MCP Prompts**: `compose-beat`, `harmonize-melody`, `arrange-tune`.
- **Tool annotations** + server `instructions`; widget→chat **"Send to chat"**.
- **Honest play-tool results** so terminal/CLI agents don't report false playback (the widget renders only in MCP-app hosts). Root cause: ext-apps capability detection is unreliable (SDK strips inbound `extensions`) and impossible on the stateless Worker — so honesty over detection.
- **Security**: removed a Strudel `innerHTML` XSS sink; `execFile` over shell `exec`; status-only upstream errors; code-point-safe query cap.
- **Worker**: KV-cached shared search, `/health`, analytics UA-minimization.
- `server.json` `remotes` entry; CLAUDE.md/README accuracy fixes.

## Verification
- `bun run build` (tsc clean) · `tsc -p worker/tsconfig.json` clean · `wrangler deploy --dry-run` bundles
- Tests **19 → 47**
- Reviews: Kimi + Codex per-phase + final 7-dimension team review → **SHIP, 0 push-blockers**

## Deferred to a v0.4.1 fast-follow (non-blocking review items)
- Worker-transport InMemoryTransport parity smoke test
- Strudel widget host-theme adaptation (`onhostcontextchanged`)
- Surface ignored `{isError:true}` from `sendMessage`/`downloadFile`
- Trim Cloudflare artifacts from the npm tarball; reword warning-path "will still play"
- Tier 3 feature: Worker hosted `/play?…` URL for real terminal/remote playback

🤖 Generated with [Claude Code](https://claude.com/claude-code)
