### PR TITLE
fix: render Strudel visuals behind the code (occlusion fix, v0.4.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-music-studio",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "description": "Two-mode MCP music studio: scored composition (ABC notation) and live performance (Strudel). Interactive ext-apps UI with sheet music rendering, 30+ instruments, style presets, and live coding REPL.",
   "keywords": [

--- a/server.json
+++ b/server.json
@@ -8,7 +8,7 @@
     "source": "github",
     "id": "1185354744"
   },
-  "version": "0.4.1",
+  "version": "0.4.2",
   "websiteUrl": "https://mcp-music-studio.linxule.workers.dev",
   "icons": [
     {
@@ -21,7 +21,7 @@
     {
       "registryType": "npm",
       "identifier": "mcp-music-studio",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "transport": {
         "type": "stdio"
       }

--- a/src/strudel-app.css
+++ b/src/strudel-app.css
@@ -154,13 +154,36 @@ html, body {
   display: block;
 }
 
-.repl-section.viz-on .cm-editor,
+/* THE occlusion fix. <strudel-editor> (StrudelMirror) wraps its CodeMirror in an
+   intermediate <div> whose background is set INLINE to var(--background) — an
+   opaque dark fill (#222-ish). That wrapper sits z-index:1 over the z-index:0
+   canvas and fully hides it; the v0.4.1 scrim only touched .cm-editor/.cm-scroller,
+   so the canvas only ever peeked out BELOW the editor box ("below, not behind").
+   Make the wrapper + editor transparent and fill the section so the canvas is a
+   true full-height backdrop; the readability scrim lives on ONE layer
+   (.cm-scroller) so it never double-darkens. !important beats the inline style. */
+.repl-section.viz-on .strudel-container > div {
+  height: 100% !important;
+  background-color: transparent !important;
+}
+
+.repl-section.viz-on .cm-editor {
+  height: 100% !important;
+  background-color: transparent !important;
+}
+
 .repl-section.viz-on .cm-scroller {
-  background-color: rgba(20, 17, 29, 0.55) !important;
+  height: 100% !important;
+  background-color: rgba(20, 17, 29, 0.5) !important;  /* single readability scrim */
 }
 
 .repl-section.viz-on .cm-gutters {
-  background-color: rgba(20, 17, 29, 0.35) !important;
+  background-color: rgba(20, 17, 29, 0.3) !important;
+}
+
+/* Lift the code off the animation for legibility (matches strudel.cc's glow). */
+.repl-section.viz-on .cm-content {
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.95);
 }
 
 /* CDN load-failure recovery affordance */

--- a/src/strudel-app.ts
+++ b/src/strudel-app.ts
@@ -1,11 +1,14 @@
 // =============================================================================
 // Strudel ext-apps client — uses @strudel/repl with layout fixes
 //
-// @strudel/repl's <strudel-editor> renders:
-//   1. A position:fixed canvas prepended to document.body (visualization)
-//   2. The CodeMirror editor in a sibling div (not inside the element)
-// We fix the layout by hiding the blank canvas and ensuring the editor
-// sibling is visible and properly sized.
+// @strudel/repl's <strudel-editor> (StrudelMirror) renders:
+//   1. A visualization canvas via getDrawContext("test-canvas"). We pre-create
+//      that canvas in static HTML so it's REUSED as an in-flow backdrop instead
+//      of a position:fixed body canvas (see strudel-app.html / .css).
+//   2. The CodeMirror editor inside a wrapper <div> whose background is set
+//      INLINE to var(--background) — an OPAQUE dark fill. That wrapper sits over
+//      the backdrop canvas and hides it; .viz-on makes it transparent in CSS so
+//      the animation shows behind the code (the v0.4.1→v0.4.2 occlusion fix).
 // =============================================================================
 
 import "./strudel-app.css";
@@ -508,7 +511,14 @@ fullscreenBtn.addEventListener("click", () => {
 });
 
 // Visuals toggle — once clicked, the user's choice sticks across re-renders.
+// Guard the reveal: visuals only PAINT when the pattern has a viz method, so
+// turning them on for a plain pattern would show an empty dark stage. Turning
+// OFF always works; turning ON requires a draw method (else nudge the user).
 vizBtn.addEventListener("click", () => {
+  if (!vizVisible && !VIZ_METHOD_RE.test(getLiveCode())) {
+    setStatus("Add .scope(), .pianoroll() or .spectrum() to the pattern to see visuals", "normal");
+    return;
+  }
   vizManual = true;
   vizVisible = !vizVisible;
   applyVizVisibility();

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 // AUTO-GENERATED from package.json by scripts/sync-version.mjs — do not edit by hand.
-export const VERSION = "0.4.1";
+export const VERSION = "0.4.2";


### PR DESCRIPTION
## The bug
v0.4.1 shipped the Strudel viz overlay **broken**: turning visuals on showed a dark stage but the pianoroll/scope animation never appeared behind the code — it only peeked out *below* the editor box.

## Root cause (3-way confirmed)
`<strudel-editor>` (StrudelMirror) wraps CodeMirror in an intermediate `<div>` whose background is set **inline** to an opaque `var(--background)`. That wrapper sits `z-index:1` over the `z-index:0` backdrop canvas and **fully occludes it**. The v0.4.1 scrim only touched `.cm-editor`/`.cm-scroller`, never the wrapper — so the canvas was covered everywhere the editor box reached. That's the "below, not behind" symptom.

- **Live DOM hit-test**: `#test-canvas` wasn't in the paint stack; an opaque `rgb(34,34,34)` div was on top. Force-painting the canvas solid magenta showed nothing on screen → proof of occlusion.
- **Codex** (read the bundle): pinned it to `this.root.style.backgroundColor = 'var(--background)'` on the wrapper.
- **Kimi**: caught a secondary bug — the manual "Visuals" toggle revealed an empty stage for patterns with no viz method.

## Fix
- `.viz-on` makes the StrudelMirror wrapper div **transparent** (`!important` beats the inline style) and fills it to the section height → the canvas is a true full-height backdrop behind **all** the code.
- **Single** readability scrim on `.cm-scroller` (0.5) instead of double-stacking; code gets a `text-shadow` for legibility.
- **Toggle guard**: clicking Visuals on a plain pattern now nudges "Add `.scope()`/`.pianoroll()`…" instead of showing an empty dark stage.

## Verification
Verified live in-browser — both `.scope()` and `.pianoroll()` render behind readable code. Build clean, 53 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)