### PR TITLE
ci: tokenless OIDC publishing + PR gate + grouped Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  # Root npm package (bun.lock) — mcp-music-studio (published).
+  # Each ecosystem is GROUPED (patterns: ["*"]) into a single PR so a refresh is
+  # ~one PR per ecosystem, not one per dependency (avoids the first-run flood).
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2
+    groups:
+      root-deps:
+        patterns: ["*"]
+
+  # Cloudflare Worker package (worker/bun.lock) — private, deploy-only.
+  - package-ecosystem: "npm"
+    directory: "/worker"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2
+    groups:
+      worker-deps:
+        patterns: ["*"]
+
+  # GitHub Actions (checkout, setup-node, setup-bun pinned in workflows).
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+# PR verify gate. The publish-mcp.yml workflow is tag-only; this runs on every
+# PR to main so regressions surface before release, not at tag time.
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: bun install --frozen-lockfile
+      - run: bun run build   # runs `tsc --noEmit` inline (no standalone typecheck script)
+      - run: bunx vitest run

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -35,15 +35,15 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Build package
         run: bun run build
 
-      - name: Publish to npm
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish to npm (OIDC Trusted Publishing)
+        run: |
+          npm install -g npm@latest   # OIDC trusted publishing needs npm >= 11.5.1
+          npm publish --ignore-scripts
 
       - name: Update server.json version
         run: |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-music-studio",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "description": "Two-mode MCP music studio: scored composition (ABC notation) and live performance (Strudel). Interactive ext-apps UI with sheet music rendering, 30+ instruments, style presets, and live coding REPL.",
   "keywords": [

--- a/server.json
+++ b/server.json
@@ -8,7 +8,7 @@
     "source": "github",
     "id": "1185354744"
   },
-  "version": "0.4.2",
+  "version": "0.4.3",
   "websiteUrl": "https://mcp-music-studio.linxule.workers.dev",
   "icons": [
     {
@@ -21,7 +21,7 @@
     {
       "registryType": "npm",
       "identifier": "mcp-music-studio",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "transport": {
         "type": "stdio"
       }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 // AUTO-GENERATED from package.json by scripts/sync-version.mjs — do not edit by hand.
-export const VERSION = "0.4.2";
+export const VERSION = "0.4.3";


### PR DESCRIPTION
Brings `mcp-music-studio` onto the same **tokenless OIDC** release pipeline as `lotus-wisdom-mcp` v0.8.0.

## What changed
- **`publish-mcp.yml`** — convert the npm step from `NPM_TOKEN` to **npm Trusted Publishing (OIDC)**: drop `NODE_AUTH_TOKEN: secrets.NPM_TOKEN`, add `npm install -g npm@latest` (OIDC needs npm ≥ 11.5.1), publish `--ignore-scripts` (CI already runs `bun run build`). The MCP Registry step already used `mcp-publisher login github-oidc`, so the pipeline is now **fully tokenless**. Install pinned to `bun install --frozen-lockfile`.
- **`ci.yml`** (new) — PR-verify gate (`bun install --frozen-lockfile` + `bun run build` + `bunx vitest run`). The publish workflow is tag-only; nothing ran on PRs before.
- **`dependabot.yml`** (new) — grouped per ecosystem (`npm /`, `npm /worker`, `github-actions`), `patterns: ["*"]`, limit 2, to avoid the first-run one-PR-per-dep flood.

## ⚠️ One-time setup required before the next release (manual, on npmjs.com)
1. **Trusted Publisher** for package `mcp-music-studio`: npmjs.com → package → Settings → Trusted Publisher → add GitHub Actions: owner `linxule`, repo `mcp-music-studio`, workflow `publish-mcp.yml`, Environment **blank**.
2. **2FA mode** = "Require 2FA **or** automation tokens" (the strict and-disallow-tokens mode rejects OIDC).
3. After the first OIDC release succeeds, delete the `NPM_TOKEN` repo secret and revoke the npm automation token.
4. The `mcp-music-studio-worker` package is private/deploy-only — **no** Trusted Publisher needed.

## Release after merge
Bump `package.json` version **above 0.4.2** (already the npm latest) → push (PR runs `ci.yml`) → `git tag vX.Y.Z && git push origin vX.Y.Z`. Worker deploy stays separate (`cd worker && bunx wrangler deploy`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)