### PR TITLE
docs: replace broken Smithery badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MCP Music Studio
 
-[![smithery badge](https://smithery.ai/badge/linxule/mcp-music-studio)](https://smithery.ai/server/linxule/mcp-music-studio)
+[![LightNow](https://lightnow.ai/badge/io.github.linxule/mcp-music-studio)](https://lightnow.ai/servers/io.github.linxule/mcp-music-studio)
 
 Two-mode creative music studio for AI: **scored composition** (ABC notation with sheet music) and **live performance** (Strudel live coding with TidalCycles). Interactive UI renders inline in Claude Desktop, claude.ai, and other MCP clients.
 


### PR DESCRIPTION
Replaces the broken Smithery badge with LightNow’s live capability badge. LightNow currently reports **5 T · 16 R · 3 P** for this server.

- [Server listing](https://lightnow.ai/servers/io.github.linxule/mcp-music-studio)
- [Badge documentation and variants](https://docs.lightnow.ai/how-to/add-capability-badge/)

Badge and destination return HTTP 200. This is a README-only change; no project code was executed.