### PR TITLE
fix(visuals): 2D presets silenced the pattern — draw calls go before it (v0.5.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-music-studio",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "description": "Two-mode MCP music studio: scored composition (ABC notation) and live performance (Strudel live coding). Interactive ext-apps widgets with sheet music rendering, in-place editing and MIDI/WAV export, all 128 General MIDI instruments, style presets, and a live REPL with Hydra shader visuals.",
   "keywords": [

--- a/src/shared/strudel-eval.ts
+++ b/src/shared/strudel-eval.ts
@@ -111,6 +111,44 @@ export function createTrace(opts: {
 /** The trace `runTraced` is currently filling, if any. */
 let active: StrudelTrace | undefined;
 
+/** Transforms recorded by all()/each() during the evaluation in progress. */
+let pendingAll: Array<(p: Any) => Any> = [];
+let pendingEach: ((p: Any) => Any) | undefined;
+
+function resetTransforms(): void {
+  pendingAll = [];
+  pendingEach = undefined;
+}
+
+/**
+ * What @strudel/core's repl() does after `_evaluate` returns: apply each(),
+ * then every all(), to the last expression's value. The REPL then substitutes
+ * `silence` for a non-Pattern; here that is reported as an error instead,
+ * because a pattern that plays silence is exactly what a validator exists to
+ * catch — the commonest cause being all()/setcps() written AFTER the pattern.
+ */
+function finishEvaluation(value: unknown): EvalResult {
+  const isPattern = (p: unknown): p is Any =>
+    !!p && typeof (p as Any).queryArc === "function";
+  const notAPattern = (): EvalResult => ({
+    pattern: undefined,
+    error: new Error(
+      "evaluated to a non-Pattern — the REPL plays the LAST expression, so the pattern must come last (all(), setcps() and the like go before it)",
+    ),
+  });
+  // Checked before the transforms run: `p => p.scope()` on undefined would
+  // throw a TypeError that names the symptom, not the cause.
+  if (!isPattern(value)) {
+    resetTransforms();
+    return notAPattern();
+  }
+  let pattern: Any = value;
+  if (pendingEach) pattern = pendingEach(pattern);
+  for (const transform of pendingAll) pattern = transform(pattern);
+  resetTransforms();
+  return isPattern(pattern) ? { pattern, error: undefined } : notAPattern();
+}
+
 // -----------------------------------------------------------------------------
 // The interrupt
 // -----------------------------------------------------------------------------
@@ -249,8 +287,16 @@ export function setupStrudel(): Promise<void> {
       setcpm: (v: unknown) => recordCps(v, 60),
       setCpm: (v: unknown) => recordCps(v, 60),
       hush: () => C.silence,
-      all: () => C.silence,
-      each: () => C.silence,
+      // Faithful to the REPL: all()/each() record a transform and return
+      // undefined; the transform is applied to the LAST expression's pattern
+      // by finishEvaluation(). Stubbing them as `silence` hid the v0.5.0
+      // preset bug (a trailing all() evaluates to undefined → silence).
+      all: (transform: (p: Any) => Any) => {
+        pendingAll.push(transform);
+      },
+      each: (transform: (p: Any) => Any) => {
+        pendingEach = transform;
+      },
       // Sample loading is a network + WebAudio concern. The URL is worth
       // recording though: it means unknown sound names are unverifiable rather
       // than wrong.
@@ -384,15 +430,14 @@ export async function evalStrudelSandboxed(
     // Verbatim from @strudel/core's safeEval (wrapExpression + wrapAsync),
     // re-nested inside an IIFE because a Script has no `return`.
     const source = `(function(){"use strict";return ((async ()=>{${output}})());})()`;
-    const pattern = await vm.runInContext(source, context, {
+    resetTransforms();
+    const value = await vm.runInContext(source, context, {
       filename: "strudel-pattern.js",
       timeout: timeoutMs,
     });
-    if (!pattern || typeof pattern.queryArc !== "function") {
-      return { pattern: undefined, error: new Error("evaluated to a non-Pattern") };
-    }
-    return { pattern, error: undefined };
+    return finishEvaluation(value);
   } catch (err) {
+    resetTransforms();
     return { pattern: undefined, error: err as Error };
   }
 }
@@ -407,12 +452,11 @@ export async function evalStrudelSandboxed(
 export async function evalStrudel(code: string): Promise<EvalResult> {
   await setupStrudel();
   try {
+    resetTransforms();
     const { pattern } = await C.evaluate(code, transpiler);
-    if (!pattern || typeof pattern.queryArc !== "function") {
-      return { pattern: undefined, error: new Error("evaluated to a non-Pattern") };
-    }
-    return { pattern, error: undefined };
+    return finishEvaluation(pattern);
   } catch (err) {
+    resetTransforms();
     return { pattern: undefined, error: err as Error };
   }
 }

--- a/src/shared/visual-presets.ts
+++ b/src/shared/visual-presets.ts
@@ -114,7 +114,17 @@ export const VISUAL_PRESET_BLURBS: Record<VisualPreset, string> = {
   "hydra-feed": "Hydra: the piano roll itself, mirrored and trailed",
 };
 
-/** Strudel 2D draw methods, keyed by preset. */
+/**
+ * Strudel 2D draw methods, keyed by preset.
+ *
+ * These go BEFORE the pattern, never after it. The REPL plays whatever the
+ * LAST expression evaluates to; `all()` only records a transform and returns
+ * undefined, so `pattern; all(...)` evaluates to undefined and the REPL plays
+ * silence — with the status still reading "Playing…". `all(...); pattern`
+ * records the transform, then the pattern is the last expression and the
+ * transform is applied to it. (v0.5.0 shipped the appended form: every 2D
+ * preset, and hydra-feed on code without its own draw method, was silent.)
+ */
 const DRAW_CALLS: Partial<Record<VisualPreset, string>> = {
   pianoroll: "all(p => p.pianoroll({ fold: 1 }))",
   punchcard: "all(p => p.punchcard())",
@@ -220,16 +230,14 @@ export function applyVisualPreset(
     const recipe = HYDRA_RECIPES[preset];
     if (!recipe) return code;
     // feedStrudel textures the STRUDEL DRAW CANVAS. With no draw method there is
-    // nothing in s0 to mirror, so give it a piano roll to chew on.
+    // nothing in s0 to mirror, so give it a piano roll to chew on — placed
+    // before the pattern, like every draw call (see DRAW_CALLS).
     const needsRoll = preset === "hydra-feed" && !intent.strudelViz;
-    // Both joins are terminated: the recipe so the pattern below it is not read
-    // as a call on `.out(o0)`, and the pattern so the appended draw call is a
-    // statement of its own. See terminateStatement().
+    // The recipe is terminated so the code below it is not read as a call on
+    // `.out(o0)`. See terminateStatement().
     const body = code.trimStart();
-    const tail = needsRoll ? `\n\n${DRAW_CALLS.pianoroll}` : "";
-    return `${terminateStatement(recipe)}\n\n${
-      needsRoll ? terminateStatement(body) : body
-    }${tail}`;
+    const roll = needsRoll ? `${DRAW_CALLS.pianoroll};\n\n` : "";
+    return `${terminateStatement(recipe)}\n\n${roll}${body}`;
   }
 
   // Strudel draw methods all share the single 2D canvas, so a pattern that
@@ -237,5 +245,7 @@ export function applyVisualPreset(
   if (intent.strudelViz) return code;
   const call = DRAW_CALLS[preset];
   if (!call) return code;
-  return `${terminateStatement(code)}\n\n${call}`;
+  // Prepended, and the pattern stays the last expression. Nothing to terminate:
+  // the call ends in `)` and the model's code follows on its own line.
+  return `${call};\n\n${code.trimStart()}`;
 }

--- a/src/strudel-app.ts
+++ b/src/strudel-app.ts
@@ -1384,6 +1384,29 @@ function readEvalError(): Error | null {
   return err instanceof Error ? err : err ? new Error(String(err)) : null;
 }
 
+/**
+ * Whether the pattern the REPL just accepted produces NO events.
+ *
+ * "Playing…" with a pattern that is `silence` is the widget's most misleading
+ * state: evaluation succeeded, the scheduler runs, nothing sounds. The REPL
+ * plays the LAST expression, so `pattern; all(...)` or `pattern; setcps(...)`
+ * hands it undefined → silence, without an error. Query-time errors are
+ * swallowed by queryArc() the same way (an empty result), so both shapes land
+ * here. Bounded to a few cycles; a slow-building pattern (`<~ ~ ~ x>`) that
+ * genuinely rests through the window is a false positive we accept, which is
+ * why the wording is "produces no events", not "is broken".
+ */
+const SILENCE_CHECK_CYCLES = 4;
+function patternIsSilent(): boolean {
+  const pattern = getEditor()?.repl?.state?.pattern;
+  if (!pattern || typeof pattern.queryArc !== "function") return false;
+  try {
+    return pattern.queryArc(0, SILENCE_CHECK_CYCLES).length === 0;
+  } catch {
+    return true;
+  }
+}
+
 /** Whether the scheduler is actually running (not what we hoped it would do). */
 function isSchedulerStarted(): boolean {
   return getEditor()?.repl?.state?.started === true;
@@ -1488,6 +1511,16 @@ function reportEvaluation(
 
   updatePlayState(isSchedulerStarted());
   markReportedPlaying(isPlaying, null);
+  if (isPlaying && patternIsSilent()) {
+    setStatus("Playing — but the pattern produces no events (silent)", "error");
+    reportToModel(
+      "Strudel widget: the pattern evaluated and the scheduler is running, but it " +
+        `produces NO events in the first ${SILENCE_CHECK_CYCLES} cycles — nothing will sound. ` +
+        "The REPL plays the LAST expression: make sure the pattern is the final statement " +
+        "(all(), setcps() and helpers go before it), and that every layer yields events.",
+    );
+    return;
+  }
   if ((soundfontWarning || tempoAtRuntime) && isPlaying) {
     setStatus(`Playing...${soundfontNote}${tempoNote}`, "playing");
   }

--- a/src/strudel-guide.ts
+++ b/src/strudel-guide.ts
@@ -878,7 +878,9 @@ note("c3 e3 g3 c4").s("sawtooth").lpf(2000).pianoroll()
 .color("cyan") / .color("#ff7aa2") tints that pattern's notes in the pianoroll
 and its highlight in the code. Pattern it for movement: .color("<cyan magenta>").
 
-To draw ALL running patterns in one roll: all(pianoroll) on its own line.
+To draw ALL running patterns in one roll: all(pianoroll) on its own line
+BEFORE the patterns. The REPL plays the LAST expression, and all() returns
+nothing — put it after your code and the whole pattern goes silent.
 .scope()/.spectrum() animate only while audio plays; .pianoroll()/.punchcard()
 animate from the note schedule, so they update live as the user edits (Ctrl+Enter).
 
@@ -1032,8 +1034,8 @@ Keep " for actual patterns: s("bd sd"), note("c3 e3"), H("1 0 0.6 0").
 
 ## The \`visuals\` parameter (a floor, not a ceiling)
 Ready-made visual for code that has none of its own:
-  none | pianoroll | punchcard | scope | spectrum — appends
-  all(p => p.<method>()) after your code, drawing every running pattern.
+  none | pianoroll | punchcard | scope | spectrum — prepends
+  all(p => p.<method>()) before your code, drawing every running pattern.
   hydra-kaleid | hydra-pulse | hydra-wash | hydra-feed — prepends a pinned
   await initHydra() shader before it (hydra-feed also adds a piano roll for
   the shader to mirror, when your code has no draw method).

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 // AUTO-GENERATED from package.json by scripts/sync-version.mjs — do not edit by hand.
-export const VERSION = "0.5.0";
+export const VERSION = "0.5.1";

--- a/tests/share-page-visuals.test.ts
+++ b/tests/share-page-visuals.test.ts
@@ -128,7 +128,7 @@ describe("the stage is revealed only for code that draws", () => {
   it.each([
     ["a plain pattern", PLAIN, ""],
     ["a draw method", ROLL, "viz-on"],
-    ["all(pianoroll)", `${PLAIN}\nall(pianoroll)`, "viz-on"],
+    ["all(pianoroll)", `all(pianoroll)\n${PLAIN}`, "viz-on"],
     ["initHydra", HYDRA, "viz-on hydra-on"],
   ])("%s → body class %o", (_label, code, expected) => {
     expect(bodyClass(generateStrudelPlayerHtml({ code }))).toBe(expected);

--- a/tests/visual-presets.test.ts
+++ b/tests/visual-presets.test.ts
@@ -15,7 +15,7 @@ import { evalStrudel, queryHaps } from "./strudel-eval";
 const PLAIN = 's("bd*2 [~ sd]").bank("RolandTR909")';
 
 describe("applyVisualPreset — draw presets", () => {
-  it("appends an all(...) draw call to a pattern with no visual", () => {
+  it("prepends an all(...) draw call to a pattern with no visual", () => {
     const out = applyVisualPreset(PLAIN, "pianoroll");
     expect(out).toContain(PLAIN);
     expect(out).toContain("all(p => p.pianoroll({ fold: 1 }))");
@@ -137,10 +137,6 @@ describe("applyVisualPreset — the concatenated result still evaluates", () => 
         const { pattern, error } = await evalStrudel(out);
         expect(error).toBeUndefined();
         expect(pattern).toBeTruthy();
-        // hydra-feed appends `all(…)`, which the headless evaluator stubs as
-        // silence (the real REPL returns the pattern), so only the other
-        // presets can be asserted on their haps.
-        if (preset === "hydra-feed") return;
         const { haps, error: queryError } = queryHaps(pattern!, 1);
         expect(queryError).toBeUndefined();
         expect(haps.length).toBeGreaterThan(0);
@@ -148,23 +144,43 @@ describe("applyVisualPreset — the concatenated result still evaluates", () => 
     }
   }
 
-  it("hydra-feed terminates the pattern before appending its piano roll", async () => {
+  it("hydra-feed puts its piano roll between the shader and the pattern", async () => {
     const out = applyVisualPreset('(() => note("c3"))()', "hydra-feed");
     expect(out).toContain("feedStrudel: true");
-    // …())();\n\nall(…) — without the `;` the draw call rode on the pattern.
-    expect(out).toMatch(/\)\(\);\n\nall\(p => p\.pianoroll/);
-    const { error } = await evalStrudel(out);
+    expect(out).toMatch(/\.out\(o0\);\n\nall\(p => p\.pianoroll\(\{ fold: 1 \}\)\);\n\n\(\(\) => note/);
+    const { pattern, error } = await evalStrudel(out);
     expect(error).toBeUndefined();
+    expect(queryHaps(pattern!, 1).haps.length).toBeGreaterThan(0);
+  });
+
+  // The v0.5.0 regression: every 2D preset was appended AFTER the pattern, so
+  // the REPL's last expression was all()'s undefined and it played silence
+  // while the status read "Playing…". The evaluator is faithful to the REPL's
+  // all() semantics precisely so this test can see it.
+  it("keeps the pattern as the last expression, so every draw preset stays audible", async () => {
+    for (const preset of ["pianoroll", "punchcard", "scope", "spectrum"] as const) {
+      const out = applyVisualPreset(PLAIN, preset);
+      expect(out.trimEnd().endsWith(PLAIN)).toBe(true);
+      const { pattern, error } = await evalStrudel(out);
+      expect(error, preset).toBeUndefined();
+      expect(queryHaps(pattern!, 1).haps.length, preset).toBeGreaterThan(0);
+    }
+  });
+
+  it("the appended form (what 0.5.0 emitted) evaluates to no pattern at all", async () => {
+    const { pattern, error } = await evalStrudel(`${PLAIN};\n\nall(p => p.scope())`);
+    expect(pattern).toBeUndefined();
+    expect(error?.message).toMatch(/LAST expression/);
   });
 
   it("puts the terminator on its own line when the code ends in a comment", () => {
     const out = applyVisualPreset('note("c3") // the tune', "pianoroll");
-    expect(out).toBe('note("c3") // the tune\n;\n\nall(p => p.pianoroll({ fold: 1 }))');
+    expect(out).toBe('all(p => p.pianoroll({ fold: 1 }));\n\nnote("c3") // the tune');
   });
 
   it("does not double up a terminator the code already has", () => {
     expect(applyVisualPreset('note("c3");', "scope")).toBe(
-      'note("c3");\n\nall(p => p.scope())',
+      'all(p => p.scope());\n\nnote("c3");',
     );
   });
 


### PR DESCRIPTION
## What

Every 2D `visuals` preset (`pianoroll`, `punchcard`, `scope`, `spectrum`) — and `hydra-feed` on code without its own draw method — produced **silence** in 0.5.0, with the widget status reading "Playing…".

The REPL plays the last expression. `all()` returns `undefined`, and the presets appended `all(p => p.<method>())` *after* the pattern.

## Fix

- Draw calls are prepended; the pattern stays the last expression.
- Guide text that taught the same silent form corrected.
- Headless evaluator: `all()`/`each()` are now faithful to `repl()` (previously stubbed as `silence`, which is what hid this from the suite). A non-Pattern result is an error naming the cause.
- Widget: a pattern with zero events over 4 cycles is reported honestly ("produces no events (silent)") in the status and via `updateModelContext`.
- Tests: each draw preset is evaluated for haps; the 0.5.0 form asserts to no pattern.

Found by the audio tap while recording the release showcase: −91 dB on exactly those scenes, −18…−24 dB after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGyGZbzdNkP2THuJDifpZL