### PR TITLE
fix(visuals): review-driven handholding, musical FFT bands, fallback `a` stub (v0.5.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-music-studio",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "type": "module",
   "description": "Two-mode MCP music studio: scored composition (ABC notation) and live performance (Strudel live coding). Interactive ext-apps widgets with sheet music rendering, in-place editing and MIDI/WAV export, all 128 General MIDI instruments, style presets, and a live REPL with Hydra shader visuals.",
   "keywords": [

--- a/server.ts
+++ b/server.ts
@@ -116,7 +116,7 @@ export async function handleGetMusicGuide({
  * that only want the neutral receipt.
  */
 export async function handlePlayLivePattern(
-  args: { code: string; title?: string },
+  args: { code: string; title?: string; visuals?: string; theme?: string },
   validate = true,
 ): Promise<CallToolResult> {
   const validation = validate ? await validateStrudelCode(args.code) : undefined;

--- a/src/shared/tool-defs.ts
+++ b/src/shared/tool-defs.ts
@@ -431,6 +431,7 @@ export const PLAY_LIVE_BASE_DESCRIPTION =
   "(pianoroll/punchcard/scope/spectrum, or hydra-kaleid/pulse/wash/feed). " +
   "`theme` sets the code-editor colour scheme, which also tints the visuals — match it to the mood " +
   "(teletext chiptune, sonicPink synthwave, nord ambient, gruvboxDark lofi). " +
+  "Each call creates a NEW player rather than updating the last one — for a tweak, send the whole revised pattern and ask the user to stop the previous one. " +
   "Use get-strudel-guide for genre templates, sound references, and advanced features " +
   "like arrangement and sample loading.";
 
@@ -448,7 +449,10 @@ export const playLiveInputSchema = z.object({
     .describe(
       "Strudel pattern code. Uses TidalCycles mini-notation in JavaScript. " +
         "Use stack() to layer drums, bass, and melody. " +
-        "Set tempo with setcps(bpm/60/4) or use the bpm parameter.",
+        "Set tempo with setcps(bpm/60/4) or use the bpm parameter. " +
+        "The REPL plays the LAST expression: setup lines (await initHydra(), all(), setcps()) go BEFORE the pattern. " +
+        "Double quotes are mini-notation — use single quotes for plain strings and URLs. " +
+        "One draw method per pattern; pass a.fft values as functions (() => a.fft[0]).",
     ),
   title: z
     .string()
@@ -474,14 +478,18 @@ export const playLiveInputSchema = z.object({
         "pianoroll/punchcard/scope/spectrum draw onto the 2D canvas behind the code; " +
         "hydra-kaleid (rotating kaleidoscope), hydra-pulse (shape driven by a rhythm), " +
         "hydra-wash (slow ambient noise) and hydra-feed (the piano roll mirrored and trailed) " +
-        "are WebGL shader backgrounds. Ignored if the code already visualises itself — " +
-        "writing your own .pianoroll() or initHydra() shader is still the better result " +
-        "(see get-strudel-guide topic 'visuals').",
+        "are WebGL shader backgrounds. A preset fills the MISSING layer: a hydra preset is skipped only if the code already calls initHydra(), " +
+        "a 2D preset only if the code already has a draw method — so hydra-wash layers happily under your own .pianoroll(). " +
+        "Hydra presets are dropped for viewers who prefer reduced motion. " +
+        "Writing your own visual is still the better result (see get-strudel-guide topic 'visuals').",
     ),
   theme: z
     .enum(EDITOR_THEMES)
     .optional()
-    .describe("Editor colour theme — pick to match the mood (e.g. 'nord', 'sonicPink', 'githubLight')."),
+    .describe(
+      "Editor colour theme; the visuals stage and its readability scrim are derived from it, so it also decides whether a shader sits on a dark or light ground — " +
+        "prefer a dark one when the visual is the point (e.g. 'nord', 'sonicPink', 'tokyoNight'). Not carried into share links or the browser fallback.",
+    ),
 });
 
 /**
@@ -530,6 +538,25 @@ function summariseValidation(v: StrudelValidation): string {
   return parts.join(", ");
 }
 
+/**
+ * What the `visuals` / `theme` parameters will do. The preset is folded into
+ * the code by the WIDGET (applyVisualPreset), after validation, so nothing in
+ * the validation summary can vouch for it — say so, or a terminal client that
+ * passed visuals: "hydra-kaleid" reads "parses OK: 3 layers" and cannot tell
+ * whether the parameter did anything.
+ */
+function presetNotes(args: { visuals?: string; theme?: string }): string[] {
+  const notes: string[] = [];
+  if (args.visuals && args.visuals !== "none") {
+    notes.push(
+      `Visual preset ${args.visuals}: applied in the widget on top of the code above` +
+        (args.visuals.startsWith("hydra-") ? " (skipped for viewers who prefer reduced motion)." : "."),
+    );
+  }
+  if (args.theme) notes.push(`Theme: ${args.theme}.`);
+  return notes;
+}
+
 /** Lines that qualify an otherwise-OK result. */
 function validationWarnings(v: StrudelValidation): string[] {
   const warnings: string[] = [];
@@ -558,7 +585,7 @@ function validationWarnings(v: StrudelValidation): string[] {
  * is the only feedback there is.
  */
 export function buildPlayLiveResult(
-  args: { code: string; title?: string },
+  args: { code: string; title?: string; visuals?: string; theme?: string },
   validation?: StrudelValidation,
   /**
    * Why no validation ran, when a transport cannot run one at all. A complete
@@ -608,7 +635,7 @@ export function buildPlayLiveResult(
     content: [
       {
         type: "text",
-        text: [head, ...validationWarnings(validation), PLAY_LIVE_PLAYBACK_TAIL].join(
+        text: [head, ...presetNotes(args), ...validationWarnings(validation), PLAY_LIVE_PLAYBACK_TAIL].join(
           "\n",
         ),
       },
@@ -1058,7 +1085,8 @@ export const MUSIC_PROMPTS: PromptDef[] = [
         `Compose a ${args.mood ? `${args.mood} ` : ""}${args.genre ?? "lofi"} pattern and play it with the play-live-pattern tool. ` +
           `First call get-strudel-guide with topic "genres" for a working ${args.genre ?? "lofi"} template, then adapt it — ` +
           `use stack() to layer drums, bass, and melody, and set a fitting tempo with setcps(). ` +
-          `For a living widget, add a visual — see get-strudel-guide topic "visuals".`,
+          `Give it something to look at: the quickest reliable route is visuals: "hydra-wash" (or hydra-pulse for beats) plus a matching theme — ` +
+          `for a hand-written or audio-reactive shader, fetch get-strudel-guide topic "visuals" instead.`,
       ),
   },
   {

--- a/src/strudel-app.ts
+++ b/src/strudel-app.ts
@@ -959,7 +959,13 @@ function syncVizTheme(): void {
 // cutoff/scale defaults were tuned for.
 // =============================================================================
 
-const ANALYSER_FFT_SIZE = 256;
+// 2048 → 1024 bins of ~23 Hz at 48 kHz, fine enough to give the kick its own
+// band. (256 gave 187 Hz bins, so "band 0" ran 0–6 kHz and "band 1" 6–12 kHz —
+// the guide's "bass band" was listening to hi-hats.)
+const ANALYSER_FFT_SIZE = 2048;
+/** Bands are log-spaced between these, like ears (and hydra's bark bands). */
+const BAND_LOW_HZ = 20;
+const BAND_HIGH_HZ = 12_000;
 const ANALYSER_SMOOTHING = 0.8;
 /** Musical range. The -100..-30 dB default squashes Strudel's output flat. */
 const ANALYSER_MIN_DB = -90;
@@ -1131,12 +1137,17 @@ function createAudioApi(): StrudelAudioApi {
       if (!node || !bytes) return;
       node.getByteFrequencyData(bytes);
       const count = api.bins.length;
-      const spacing = Math.max(1, Math.floor(bytes.length / count));
+      // Log-spaced band edges in bin indices, so fft[0] is the kick/sub band
+      // and fft[3] the hats — not four equal slices of a linear spectrum.
+      const hzPerBin = node.context.sampleRate / node.fftSize;
+      const ratio = Math.pow(BAND_HIGH_HZ / BAND_LOW_HZ, 1 / count);
       api.prevBins = api.bins.slice(0);
       let total = 0;
       for (let i = 0; i < count; i++) {
-        const start = i * spacing;
-        const end = Math.min(start + spacing, bytes.length);
+        const lo = BAND_LOW_HZ * Math.pow(ratio, i);
+        const hi = lo * ratio;
+        const start = Math.min(bytes.length - 1, Math.floor(lo / hzPerBin));
+        const end = Math.min(bytes.length, Math.max(start + 1, Math.ceil(hi / hzPerBin)));
         let sum = 0;
         for (let j = start; j < end; j++) sum += bytes[j];
         // Mean magnitude 0..1, then into hydra's loudness units via `max`.
@@ -1407,6 +1418,9 @@ function patternIsSilent(): boolean {
   }
 }
 
+/** Set when a hydra `visuals` preset was dropped for prefers-reduced-motion. */
+let hydraPresetSkippedForMotion = false;
+
 /** Whether the scheduler is actually running (not what we hoped it would do). */
 function isSchedulerStarted(): boolean {
   return getEditor()?.repl?.state?.started === true;
@@ -1529,9 +1543,12 @@ function reportEvaluation(
     intent.hydra ? "hydra shader" : null,
     intent.strudelViz ? "strudel draw canvas" : null,
   ].filter(Boolean);
+  const motionNote = hydraPresetSkippedForMotion
+    ? " — hydra preset skipped: this viewer prefers reduced motion"
+    : "";
   reportToModel(
     `Strudel widget: ${isPlaying ? "playing" : "loaded, not playing"}` +
-      ` (visuals: ${layers.length ? layers.join(" + ") : "none"})${soundfontNote}${tempoNote}`,
+      ` (visuals: ${layers.length ? layers.join(" + ") : "none"}${motionNote})${soundfontNote}${tempoNote}`,
   );
 }
 
@@ -1974,9 +1991,10 @@ async function renderPattern(args: Record<string, unknown>) {
     // keeps `await initHydra()` on the first line where the engine expects it.
     // Reduced motion drops the Hydra presets (a WebGL shader is exactly the
     // continuous animation that setting is asking us not to start).
-    finalCode = applyVisualPreset(finalCode, args.visuals, {
-      allowHydra: !prefersReducedMotion(),
-    });
+    const reduced = prefersReducedMotion();
+    hydraPresetSkippedForMotion =
+      reduced && typeof args.visuals === "string" && args.visuals.startsWith("hydra-");
+    finalCode = applyVisualPreset(finalCode, args.visuals, { allowHydra: !reduced });
     currentCode = finalCode;
     pendingPartialCode = "";
 

--- a/src/strudel-browser-fallback.ts
+++ b/src/strudel-browser-fallback.ts
@@ -265,6 +265,22 @@ export function generateStrudelPlayerHtml(options: StrudelPlayerOptions): string
     };
   });
 
+  // The widget publishes an audio-reactive \`a\` (hydra's audio object over
+  // Strudel's master bus). This page has no such tap, so give the recipes a
+  // silent stand-in: every band reads 0 and the setters are no-ops. The shader
+  // runs; it just does not react — the guide says so.
+  (function () {
+    var zeros = [0, 0, 0, 0];
+    var noop = function () {};
+    var stub = { fft: zeros, bins: zeros, vol: 0, setBins: function (n) { zeros.length = 0; for (var i = 0; i < (n || 4); i++) zeros.push(0); }, setSmooth: noop, setCutoff: noop, setScale: noop, show: noop, hide: noop };
+    var zeroFn = function () { return function () { return 0; }; };
+    var define = function (key, value) {
+      Object.defineProperty(globalThis, key, { configurable: true, enumerable: true, get: function () { return value; }, set: function () {} });
+    };
+    if (typeof globalThis.a === 'undefined') define('a', stub);
+    ['a0', 'a1', 'a2', 'a3'].forEach(function (k) { if (typeof globalThis[k] === 'undefined') define(k, zeroFn); });
+  })();
+
   // Upstream H is  p => () => reify(p).queryArc(t, t)[0].value  — a zero-width
   // query. Under a REST there is no hap, so [0] is undefined and reading
   // .value throws. Hydra calls this every frame, so one rest killed the shader

--- a/src/strudel-guide.ts
+++ b/src/strudel-guide.ts
@@ -509,6 +509,11 @@ note("c3 [e3 g3] a3 g3")
 Complete, working examples. Copy and modify.
 Each template notes which features it showcases.
 
+Every template here is silent VISUALLY. Give the widget something to look at:
+add ONE draw method (.pianoroll() on the melodic layer) or pass the visuals
+parameter (hydra-wash for ambient, hydra-pulse for beats) with a matching
+theme — see topic "visuals" for Hydra backgrounds and audio-reactive shaders.
+
 ## Techno
 // Features: stack(), .bank(), .lpq() resonance, continuous signal panning
 setcps(0.5416)
@@ -677,7 +682,8 @@ The bpm parameter auto-converts to setcps() for you:
 - If code already has setcps(), bpm REPLACES it
 - Best practice: use the bpm parameter and omit setcps() from code
 - Or: write setcps() in code and omit the bpm parameter
-- Don't use both — bpm always wins
+- Don't use both. bpm replaces one simple numeric setcps(); a computed or
+  repeated setter in the code can still win — then omit bpm and trust the code
 
 ### autoplay parameter
 Due to browser autoplay policies, AudioContext starts suspended until
@@ -900,7 +906,8 @@ Rules:
   detectAudio: true — that is hydra's own microphone capture, and it prompts.
 - Quote plain strings with ' not " (see "Single quotes" below).
 - The hydra-synth version is pinned for you, so a bare await initHydra() is
-  reproducible; pass \`src\` only to override it.
+  reproducible. Do NOT pass \`src\` — it is a remote-code-load switch and the
+  pinned version is the tested one.
 - Hydra + one Strudel draw method is fine; the roll draws on top of the shader.
 
 ### Recipe: minimal moving background
@@ -936,7 +943,7 @@ Drive a parameter from a rhythm pattern (values 0–1). Wrap H() in an arrow
 function when you want to remap it.
 
 await initHydra()
-const pulse = "1 0 0.6 0 1 0 0.3 0.3"
+const pulse = "1 0.8 0 1 0.8 0.8 0 1"   // one value per eighth, 1 on each kick
 shape(6, () => 0.15 + 0.35 * H(pulse)(), 0.3)
   .repeat(3, 3)
   .modulateRotate(osc(4, 0.1), 0.4)
@@ -979,8 +986,11 @@ the speakers get. No getUserMedia, no permission prompt — it reacts to the
 pattern that is playing. It is live once Hydra is up; before that the bands
 simply read 0, so a shader never crashes on it.
 
-  a.fft[0..3]      band levels, low → high. fft[0] is the kick band.
+  a.fft[0..3]      band levels, low → high, on log-spaced MUSICAL bands:
+                   fft[0] 20–100 Hz (kick, sub)   fft[1] 100–490 Hz (bass)
+                   fft[2] 490–2400 Hz (mids)      fft[3] 2.4–12 kHz (hats, air)
                    ~0 in silence, ~1 on a loud hit (can go past 1).
+                   setBins(n) re-spaces the bands logarithmically over 20 Hz–12 kHz.
   a.bins           the smoothed band values fft is derived from
   a.vol            mean of bins — overall loudness
   a0(scale, off)   … a3(scale, off): shorthand for
@@ -996,6 +1006,14 @@ simply read 0, so a shader never crashes on it.
 Same formula and defaults as hydra-synth, so hydra tutorials that read a.fft[0]
 or a0() work here verbatim. Barely moving? Lower setCutoff or setScale.
 Twitchy? Raise setSmooth toward 0.8.
+
+Share links and the browser fallback page have no live \`a\` — there it reads
+0 everywhere (the shader still runs, it just does not react). For a visual that
+must work on the share page too, drive it with H(pattern) instead.
+
+Photosensitivity: the reactive recipes flash on every hit. Keep full-frame
+brightness changes under ~3 per second and prefer colour/scale modulation over
+hard strobing; the user may be showing this on a big screen.
 
 PASS IT AS A FUNCTION. \`osc(10, 0, a.fft[0])\` reads the value once, at
 evaluation time, and freezes; \`osc(10, 0, () => a.fft[0])\` is re-read every
@@ -1061,9 +1079,12 @@ Ready-made visual for code that has none of its own:
   hydra-kaleid | hydra-pulse | hydra-wash | hydra-feed — prepends a pinned
   await initHydra() shader before it (hydra-feed also adds a piano roll for
   the shader to mirror, when your code has no draw method).
-Skipped when the code already has a draw method or calls initHydra(), and the
-hydra presets are skipped entirely under prefers-reduced-motion. Writing your
-own visual, as above, is still the better result.
+A preset fills the MISSING layer: a hydra preset is skipped only when the code
+already calls initHydra(); a 2D preset only when the code already has a draw
+method. So hydra-wash under your own .pianoroll() is fine — and recommended.
+"none" leaves the code untouched. Hydra presets are dropped entirely under
+prefers-reduced-motion (the widget tells the model when that happened). Writing
+your own visual, as above, is still the better result.
 
 ## The \`theme\` parameter (editor colour scheme)
 Sets the CodeMirror theme, and the widget derives the visuals stage and scrim

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 // AUTO-GENERATED from package.json by scripts/sync-version.mjs — do not edit by hand.
-export const VERSION = "0.5.2";
+export const VERSION = "0.5.3";


### PR DESCRIPTION
Two independent reviews (Opus, Codex) of the agent-facing visuals text:

- CONTRADICTION: `visuals` was documented as "ignored if the code already
  visualises itself"; applyVisualPreset actually fills the MISSING layer
  (hydra presets skip only on initHydra(), 2D presets only on a draw method).
  Param description + guide now say so, and recommend the combination.
- GAP: a.fft "bands" were four equal slices of a linear 0–24 kHz spectrum at
  fftSize 256 — fft[1], documented as the bass band, covered 6–12 kHz. Bands
  are now log-spaced 20 Hz–12 kHz at fftSize 2048 (fft[0] 20–100 Hz kick/sub,
  fft[1] 100–490 bass, fft[2] mids, fft[3] hats). Measured: kick → [.86 .87
  .23 0], hats → [.33 .39 .44 .46].
- GAP: the share/browser page had no `a` object, so an audio-reactive share
  link threw. A silent stand-in (zeros, no-op setters) keeps the shader alive;
  the guide says to use H() for share-safe reactivity.
- GAP: the tool result never mentioned the preset (folded in client-side);
  it now notes "Visual preset X: applied in the widget…" and the theme.
- GAP: reduced motion silently dropped hydra presets; the widget report and
  the param description now say so.
- GAP: "each call creates a NEW player" was only in a code comment; now in
  the tool description. Load-bearing rules (last expression, single quotes,
  one draw method, a.fft as a function) now sit on the `code` parameter.
- The 'genres' topic — the recommended first read — gains a one-paragraph
  pointer to visuals; compose-beat suggests the two-call preset route.
- Guide nits: kick-pulse recipe's pulse string now matches its drum pattern;
  `src` override discouraged (remote-code switch); photosensitivity note;
  "bpm always wins" softened to what tempo.ts actually does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGyGZbzdNkP2THuJDifpZL