### PR TITLE
docs(visuals): second review pass — Tool Parameters stub, last-expression rule, H() returns a function, third-person player tail, Hydra parse-only note (v0.5.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-music-studio",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "type": "module",
   "description": "Two-mode MCP music studio: scored composition (ABC notation) and live performance (Strudel live coding). Interactive ext-apps widgets with sheet music rendering, in-place editing and MIDI/WAV export, all 128 General MIDI instruments, style presets, and a live REPL with Hydra shader visuals.",
   "keywords": [

--- a/src/shared/tool-defs.ts
+++ b/src/shared/tool-defs.ts
@@ -62,7 +62,7 @@ export const SERVER_INSTRUCTIONS =
   "Before composing, consult the reference tools: get-music-guide (ABC — start with " +
   "topic 'genres' for templates, 'styles' for accompaniment presets, 'instruments' for the list) " +
   "or get-strudel-guide (Strudel — 'genres', 'sounds', 'effects'; 'visuals' for the animation layer). " +
-  "play-live-pattern can paint as well as play: pass visuals (a preset) and theme, or write " +
+  "play-live-pattern can paint as well as play: add .pianoroll() to a pattern, pass visuals (a preset) and theme, or write " +
   "`await initHydra()` shader code that follows the music via H(pattern) and a.fft — the " +
   "'visuals' topic has copy-ready recipes. Use search-music-docs only " +
   "when the curated guides don't cover something. For ABC accompaniment, include chord symbols " +
@@ -236,10 +236,10 @@ export const PLAY_SHEET_FALLBACK_SUFFIX =
 // from a dead end into an instruction — see `attachPlayLink`.
 
 export const NO_INLINE_PLAYER_TAIL =
-  "If you don't see a player here, this client can't play it inline, so nothing has played yet.";
+  "The server cannot tell whether a player rendered: if the user reports no player, this client can't play it inline and nothing has played yet.";
 
 export const NO_INLINE_PLAYER_TAIL_WITH_LINK =
-  "If you don't see a player here, this client can't play it inline — click the link below to play it in your browser.";
+  "The server cannot tell whether a player rendered: if the user reports no player, this client can't play it inline — give them the link below to play it in the browser.";
 
 /** Prefix of the line carrying the hosted player URL. */
 export const PLAY_LINK_PREFIX = "\u25b6 Play in browser: ";
@@ -533,7 +533,7 @@ function summariseValidation(v: StrudelValidation): string {
   } else if (v.usesNotes) {
     parts.push("notes with no sound named (plays on the default triangle synth)");
   }
-  if (v.usesHydra) parts.push("Hydra background: yes");
+  if (v.usesHydra) parts.push("Hydra background: yes (parse-checked only — shader calls and a.fft are not executed here)");
   if (v.visuals?.length) parts.push(`visuals: ${v.visuals.join(", ")}`);
   return parts.join(", ");
 }

--- a/src/strudel-guide.ts
+++ b/src/strudel-guide.ts
@@ -708,6 +708,13 @@ from the network on first use. There may be a brief delay (~1-2 seconds)
 the first time a GM instrument plays. After that, it's cached.
 Built-in synths (sine, sawtooth, square) play instantly with no loading.
 
+### visuals / theme parameters
+visuals: a ready-made animation for code that has none (pianoroll | punchcard |
+scope | spectrum | hydra-kaleid | hydra-pulse | hydra-wash | hydra-feed); it
+fills the layer your code lacks. theme: the editor colour scheme, which also
+sets the ground the visuals sit on. Both are documented in full — with the
+Hydra and audio-reactive recipes — in topic "visuals".
+
 ## Each Call Renders a Fresh Widget
 Every play-live-pattern call creates a new independent widget. Sending
 a follow-up call doesn't update an existing pattern — it creates another.
@@ -766,6 +773,13 @@ rather than trying to "update" the previous one.
     JS string written with " fails at eval with \`[mini] parse error\`.
     WRONG:  await initHydra({ src: "https://unpkg.com/hydra-synth@1.4.0" })
     RIGHT:  await initHydra({ src: 'https://unpkg.com/hydra-synth@1.4.0' })
+
+12. The REPL plays the LAST expression
+    all(), setcps(), await initHydra(), const declarations and every other
+    helper go BEFORE the pattern. Put anything after it and the widget plays
+    silence while the status still reads "Playing".
+    WRONG:  s("bd*4"); all(p => p.pianoroll())
+    RIGHT:  all(p => p.pianoroll()); s("bd*4")
     WRONG:  samples("github:tidalcycles/dirt-samples")
     RIGHT:  samples('github:tidalcycles/dirt-samples')
     Keep " for real patterns: s("bd sd"), note("c3 e3"), H("1 0 0.6 0").
@@ -918,7 +932,9 @@ s("bd*2 [~ sd] hh*4").bank("RolandTR909")
 
 ### Recipe: pattern drives the shader with H()
 H(pattern) turns a Strudel pattern into a live value Hydra reads every frame,
-so the visual follows the SAME sequence the music plays.
+so the visual follows the SAME sequence the music plays. H(p) returns a
+FUNCTION: pass it bare where Hydra takes a parameter (shape(H(seq), …)), and
+call it — H(p)() — inside your own arrow when you remap the value.
 
 AVOID ~ RESTS IN AN H() PATTERN. H is
   o => () => reify(o).queryArc(getTime(), getTime())[0].value
@@ -1137,7 +1153,10 @@ Output:   .out(o0)
 - Nothing visible: you probably forgot .out(o0), or the colors are too dark.
 - Choppy audio: simplify the shader (fewer modulate/kaleid stages).
 - The pattern used Hydra before but not now: the widget stops the old shader
-  automatically; add initHydra() again to bring it back.`,
+  automatically; add initHydra() again to bring it back.
+- Iterating ("now make it react to the bass"): every tool call is a NEW
+  widget, not an update — send the whole revised pattern, and ask the user to
+  stop the previous player, or two will sound at once.`,
   advanced: `# Strudel Advanced Features
 
 ## Visualization

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 // AUTO-GENERATED from package.json by scripts/sync-version.mjs — do not edit by hand.
-export const VERSION = "0.5.3";
+export const VERSION = "0.5.4";

--- a/tests/strudel.test.ts
+++ b/tests/strudel.test.ts
@@ -32,8 +32,8 @@ describe("play-live-pattern handler", () => {
     expect(result.content[0]?.text).toBe(
       "Strudel pattern ready — parses OK: 2 events/cycle, sounds: bd sd (all registered).\n" +
         "It plays in an editable REPL widget in MCP-app hosts " +
-        "(e.g. Claude Desktop, claude.ai). If you don't see a player here, this client can't play it " +
-        "inline, so nothing has played yet.",
+        "(e.g. Claude Desktop, claude.ai). The server cannot tell whether a player rendered: if the user " +
+        "reports no player, this client can't play it inline and nothing has played yet.",
     );
   });
 
@@ -42,8 +42,8 @@ describe("play-live-pattern handler", () => {
 
     expect(result.content[0]?.text).toBe(
       "Strudel pattern ready. It plays in an editable REPL widget in MCP-app hosts " +
-        "(e.g. Claude Desktop, claude.ai). If you don't see a player here, this client can't play it " +
-        "inline, so nothing has played yet.",
+        "(e.g. Claude Desktop, claude.ai). The server cannot tell whether a player rendered: if the user " +
+        "reports no player, this client can't play it inline and nothing has played yet.",
     );
     expect(result.content[0]?.text).not.toContain('"');
   });


### PR DESCRIPTION
Remaining items from the Opus/Codex visuals-doc reviews: 'Tool Parameters' now lists visuals/theme; Critical Rule 12 (the REPL plays the LAST expression); H() documented as returning a function; the no-player tail is third person (the model cannot see the widget); 'Hydra background: yes' says it is parse-checked only; server instructions mention the draw-method layer; visuals troubleshooting notes that each call is a new widget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGyGZbzdNkP2THuJDifpZL