### PR TITLE
feat(guide): split the 13 KB 'visuals' topic into 'visuals' + 'hydra' (v0.5.5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-music-studio",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "type": "module",
   "description": "Two-mode MCP music studio: scored composition (ABC notation) and live performance (Strudel live coding). Interactive ext-apps widgets with sheet music rendering, in-place editing and MIDI/WAV export, all 128 General MIDI instruments, style presets, and a live REPL with Hydra shader visuals.",
   "keywords": [

--- a/src/shared/tool-defs.ts
+++ b/src/shared/tool-defs.ts
@@ -61,10 +61,10 @@ export const SERVER_INSTRUCTIONS =
   "play-live-pattern (write Strudel/TidalCycles code → an editable live-coding REPL). " +
   "Before composing, consult the reference tools: get-music-guide (ABC — start with " +
   "topic 'genres' for templates, 'styles' for accompaniment presets, 'instruments' for the list) " +
-  "or get-strudel-guide (Strudel — 'genres', 'sounds', 'effects'; 'visuals' for the animation layer). " +
+  "or get-strudel-guide (Strudel — 'genres', 'sounds', 'effects'; 'visuals' and 'hydra' for the animation layers). " +
   "play-live-pattern can paint as well as play: add .pianoroll() to a pattern, pass visuals (a preset) and theme, or write " +
   "`await initHydra()` shader code that follows the music via H(pattern) and a.fft — the " +
-  "'visuals' topic has copy-ready recipes. Use search-music-docs only " +
+  "'hydra' topic has copy-ready recipes. Use search-music-docs only " +
   "when the curated guides don't cover something. For ABC accompaniment, include chord symbols " +
   '("C", "Am7") above the notes and set a style. ' +
   "If unsure about chord spelling or the key, call analyze-harmony; " +
@@ -426,7 +426,7 @@ export const PLAY_LIVE_BASE_DESCRIPTION =
   "(or .punchcard()/.scope()/.spectrum() — one draw method per pattern). " +
   "For a custom animated background, start the code with `await initHydra()` and write " +
   "Hydra shader code — H(pattern) locks it to the sequence, and `() => a.fft[0]` makes it " +
-  "react to the audio itself (Strudel's output, not the mic); see get-strudel-guide topic 'visuals'. " +
+  "react to the audio itself (Strudel's output, not the mic); see get-strudel-guide topic 'hydra'. " +
   "Rather not hand-write one? `visuals` picks a ready-made animation for code that has none " +
   "(pianoroll/punchcard/scope/spectrum, or hydra-kaleid/pulse/wash/feed). " +
   "`theme` sets the code-editor colour scheme, which also tints the visuals — match it to the mood " +
@@ -481,7 +481,7 @@ export const playLiveInputSchema = z.object({
         "are WebGL shader backgrounds. A preset fills the MISSING layer: a hydra preset is skipped only if the code already calls initHydra(), " +
         "a 2D preset only if the code already has a draw method — so hydra-wash layers happily under your own .pianoroll(). " +
         "Hydra presets are dropped for viewers who prefer reduced motion. " +
-        "Writing your own visual is still the better result (see get-strudel-guide topic 'visuals').",
+        "Writing your own visual is still the better result (draw methods: topic 'visuals'; shaders: topic 'hydra').",
     ),
   theme: z
     .enum(EDITOR_THEMES)
@@ -665,13 +665,13 @@ export const GET_STRUDEL_GUIDE_DESCRIPTION =
   "patterns (transformations, probability, euclidean, arrangement), " +
   "genres (complete templates: techno/house/dnb/ambient/jazz/lofi/synthwave), " +
   "tips (tempo, common mistakes, ABC↔Strudel crossover), " +
-  "visuals (pianoroll/scope draw methods, Hydra shader backgrounds, audio-reactive shaders, "
-  + "plus the visuals/theme parameters), " +
+  "visuals (pianoroll/scope draw methods, the visuals presets and the theme parameter), " +
+  "hydra (WebGL shader backgrounds: initHydra, H(pattern), the audio-reactive a.fft object, recipes, cheat-sheet), " +
   "advanced (sample loading, wavetables, ZZFX, continuous signals, chord voicings).";
 
 export const GET_STRUDEL_GUIDE_TOPIC_DESCRIPTION =
   "Reference topic. Start with 'genres' for working templates, " +
-  "'sounds' for instruments, 'visuals' for animations and Hydra backgrounds, " +
+  "'sounds' for instruments, 'visuals' for draw methods and presets, 'hydra' for shader backgrounds, " +
   "'advanced' for sample loading.";
 
 // -----------------------------------------------------------------------------
@@ -1086,7 +1086,7 @@ export const MUSIC_PROMPTS: PromptDef[] = [
           `First call get-strudel-guide with topic "genres" for a working ${args.genre ?? "lofi"} template, then adapt it — ` +
           `use stack() to layer drums, bass, and melody, and set a fitting tempo with setcps(). ` +
           `Give it something to look at: the quickest reliable route is visuals: "hydra-wash" (or hydra-pulse for beats) plus a matching theme — ` +
-          `for a hand-written or audio-reactive shader, fetch get-strudel-guide topic "visuals" instead.`,
+          `for a hand-written or audio-reactive shader, fetch get-strudel-guide topic "hydra" instead.`,
       ),
   },
   {

--- a/src/strudel-guide.ts
+++ b/src/strudel-guide.ts
@@ -10,6 +10,7 @@ export const STRUDEL_GUIDE_TOPICS = [
   "genres",
   "tips",
   "visuals",
+  "hydra",
   "advanced",
 ] as const;
 
@@ -512,7 +513,7 @@ Each template notes which features it showcases.
 Every template here is silent VISUALLY. Give the widget something to look at:
 add ONE draw method (.pianoroll() on the melodic layer) or pass the visuals
 parameter (hydra-wash for ambient, hydra-pulse for beats) with a matching
-theme — see topic "visuals" for Hydra backgrounds and audio-reactive shaders.
+theme — topic "visuals" for draw methods and presets, topic "hydra" for shaders and audio-reactive visuals.
 
 ## Techno
 // Features: stack(), .bank(), .lpq() resonance, continuous signal panning
@@ -713,7 +714,7 @@ visuals: a ready-made animation for code that has none (pianoroll | punchcard |
 scope | spectrum | hydra-kaleid | hydra-pulse | hydra-wash | hydra-feed); it
 fills the layer your code lacks. theme: the editor colour scheme, which also
 sets the ground the visuals sit on. Both are documented in full — with the
-Hydra and audio-reactive recipes — in topic "visuals".
+presets — in topic "visuals"; shaders and audio-reactive recipes in topic "hydra".
 
 ## Each Call Renders a Fresh Widget
 Every play-live-pattern call creates a new independent widget. Sending
@@ -844,27 +845,25 @@ Latin:    s("[bd ~ ~ bd] [~ ~ bd ~]")
 Halftime: s("bd ~ ~ ~ [~ sd] ~ ~ ~")
 Fills:    .lastOf(8, () => s("bd sd [sd sd] [sd sd sd sd]"))   // a FUNCTION — every/lastOf take x => ...`,
 
-  visuals: `# Strudel Visuals (draw methods + Hydra shaders)
+  visuals: `# Strudel Visuals (draw methods, presets, theme)
 
-Two visual layers render BEHIND the code in the widget (native strudel.cc
-look), plus one audio-reactive input that can drive either. The layers appear
-automatically when your pattern uses them — the user can also toggle them with
-the "Visuals" button, and hide the code entirely with "Stage". Encourage
-visuals: they make the pattern legible and the widget feel alive.
+Visuals render BEHIND the code in the widget (native strudel.cc look). Two
+layers, and this topic covers the first plus the two parameters:
 
   Layer 1 — Strudel draw methods (2D canvas): .pianoroll(), .scope(), ...
-  Layer 2 — Hydra (WebGL shaders): await initHydra() then hydra code.
-  Input   — \`a\`, the live level of Strudel's OWN audio (never the microphone),
-            for making a shader move with the music.
+            — below.
+  Layer 2 — Hydra WebGL shaders (await initHydra(), H(), the audio-reactive
+            \`a\` object, the cheat-sheet) — topic "hydra".
 
-Use them together: Hydra paints a moving background, the pianoroll draws the
-notes on top of it.
+The layers appear automatically when your pattern uses them; the user can
+toggle them with "Visuals" and hide the code with "Stage". Encourage visuals:
+they make the pattern legible and the widget feel alive. Hydra + one draw
+method is the strongest look — the roll draws on top of the shader.
 
-No hand-written visual? Set the \`visuals\` parameter to a preset instead — and
-\`theme\` to a colour scheme that fits the mood. Both are documented at the
-bottom of this topic.
+No hand-written visual? Set the \`visuals\` parameter to a preset — and
+\`theme\` to a colour scheme that fits the mood. Both are documented below.
 
-## Layer 1: Strudel draw methods
+## Draw methods (Layer 1)
 Add ONE draw method to a pattern (all of them share the same 2D canvas, so two
 at once fight over it).
 
@@ -904,9 +903,65 @@ nothing — put it after your code and the whole pattern goes silent.
 .scope()/.spectrum() animate only while audio plays; .pianoroll()/.punchcard()
 animate from the note schedule, so they update live as the user edits (Ctrl+Enter).
 
-## Layer 2: Hydra shader backgrounds
-Hydra (hydra.ojack.xyz) is a live-coding video synth. It is bundled with the
-REPL: put \`await initHydra()\` on the FIRST line, write hydra code, then your
+## The \`visuals\` parameter (a floor, not a ceiling)
+Ready-made visual for code that has none of its own:
+  none | pianoroll | punchcard | scope | spectrum — prepends
+  all(p => p.<method>()) before your code, drawing every running pattern.
+  hydra-kaleid | hydra-pulse | hydra-wash | hydra-feed — prepends a pinned
+  await initHydra() shader before it (hydra-feed also adds a piano roll for
+  the shader to mirror, when your code has no draw method).
+A preset fills the MISSING layer: a hydra preset is skipped only when the code
+already calls initHydra(); a 2D preset only when the code already has a draw
+method. So hydra-wash under your own .pianoroll() is fine — and recommended.
+"none" leaves the code untouched. Hydra presets are dropped entirely under
+prefers-reduced-motion (the widget tells the model when that happened). Writing
+your own visual, as above, is still the better result.
+
+## The \`theme\` parameter (editor colour scheme)
+Sets the CodeMirror theme, and the widget derives the visuals stage and scrim
+from it — so the theme also decides whether the animation sits on a dark or a
+light ground. One of:
+
+  strudelTheme algoboy archBtw androidstudio atomone aura bbedit blackscreen
+  bluescreen bluescreenlight CutiePi darcula dracula duotoneDark eclipse
+  fruitDaw githubDark githubLight greenText gruvboxDark gruvboxLight sonicPink
+  materialDark materialLight monokai noctisLilac nord redText solarizedDark
+  solarizedLight sublime teletext tokyoNight tokyoNightDay tokyoNightStorm
+  vscodeDark vscodeLight whitescreen xcodeLight
+
+Mood pairings that work:
+  teletext            chiptune / 8-bit / breakcore
+  sonicPink           synthwave / vaporwave / italo
+  nord, tokyoNight    ambient / downtempo / drone
+  gruvboxDark         lofi / jazz-hop / dusty boom-bap
+The light themes (githubLight, solarizedLight, xcodeLight, tokyoNightDay) suit
+a bright room, but a light ground flattens a shader — the scrim compensates by
+going heavier, which mutes the visual further. Prefer a dark theme when the
+visual is the point.
+
+## Stage mode
+The user can press "Stage" to hide the code completely and ⛶ to go fullscreen,
+leaving only the animation — so make the visual worth watching on its own, not
+just as a backdrop for text.
+
+### Troubleshooting (draw methods)
+- Nothing visible: the pattern has no draw method and no visuals preset, or
+  .scope()/.spectrum() is waiting for audio (they draw only while sound plays).
+- Two draw methods flicker: they share one canvas — keep one per pattern, or
+  use all(p => p.<method>()) BEFORE the patterns to draw everything in one.
+- Iterating ("now add a shader"): every tool call is a NEW widget, not an
+  update — send the whole revised pattern and ask the user to stop the
+  previous player.`,
+  hydra: `# Strudel Hydra Shaders (Layer 2) and audio-reactive \`a\`
+
+Hydra (hydra.ojack.xyz) is a live-coding video synth bundled with the REPL: a
+WebGL shader that renders BEHIND the code. This topic is the shader layer;
+draw methods (.pianoroll() etc.), the \`visuals\` presets and \`theme\` are in
+topic "visuals". Use both together: Hydra paints the background, the piano
+roll draws the notes on top of it.
+
+## Writing a shader
+Put \`await initHydra()\` on the FIRST line, write hydra code, then your
 Strudel patterns. Hydra runs its own render loop, so it keeps animating between
 pattern re-evaluations.
 
@@ -1088,47 +1143,6 @@ Use ' for URLs, option strings, and labels:
 
 Keep " for actual patterns: s("bd sd"), note("c3 e3"), H("1 0 0.6 0").
 
-## The \`visuals\` parameter (a floor, not a ceiling)
-Ready-made visual for code that has none of its own:
-  none | pianoroll | punchcard | scope | spectrum — prepends
-  all(p => p.<method>()) before your code, drawing every running pattern.
-  hydra-kaleid | hydra-pulse | hydra-wash | hydra-feed — prepends a pinned
-  await initHydra() shader before it (hydra-feed also adds a piano roll for
-  the shader to mirror, when your code has no draw method).
-A preset fills the MISSING layer: a hydra preset is skipped only when the code
-already calls initHydra(); a 2D preset only when the code already has a draw
-method. So hydra-wash under your own .pianoroll() is fine — and recommended.
-"none" leaves the code untouched. Hydra presets are dropped entirely under
-prefers-reduced-motion (the widget tells the model when that happened). Writing
-your own visual, as above, is still the better result.
-
-## The \`theme\` parameter (editor colour scheme)
-Sets the CodeMirror theme, and the widget derives the visuals stage and scrim
-from it — so the theme also decides whether the animation sits on a dark or a
-light ground. One of:
-
-  strudelTheme algoboy archBtw androidstudio atomone aura bbedit blackscreen
-  bluescreen bluescreenlight CutiePi darcula dracula duotoneDark eclipse
-  fruitDaw githubDark githubLight greenText gruvboxDark gruvboxLight sonicPink
-  materialDark materialLight monokai noctisLilac nord redText solarizedDark
-  solarizedLight sublime teletext tokyoNight tokyoNightDay tokyoNightStorm
-  vscodeDark vscodeLight whitescreen xcodeLight
-
-Mood pairings that work:
-  teletext            chiptune / 8-bit / breakcore
-  sonicPink           synthwave / vaporwave / italo
-  nord, tokyoNight    ambient / downtempo / drone
-  gruvboxDark         lofi / jazz-hop / dusty boom-bap
-The light themes (githubLight, solarizedLight, xcodeLight, tokyoNightDay) suit
-a bright room, but a light ground flattens a shader — the scrim compensates by
-going heavier, which mutes the visual further. Prefer a dark theme when the
-visual is the point.
-
-## Stage mode
-The user can press "Stage" to hide the code completely and ⛶ to go fullscreen,
-leaving only the animation — so make the visual worth watching on its own, not
-just as a backdrop for text.
-
 ### Hydra cheat-sheet (the parts that matter here)
 Sources:  osc(freq, sync, offset) noise(scale, speed) voronoi(scale, speed)
           shape(sides, radius, smoothing) gradient(speed) solid(r, g, b) src(s0|o0)
@@ -1155,8 +1169,8 @@ Output:   .out(o0)
 - The pattern used Hydra before but not now: the widget stops the old shader
   automatically; add initHydra() again to bring it back.
 - Iterating ("now make it react to the bass"): every tool call is a NEW
-  widget, not an update — send the whole revised pattern, and ask the user to
-  stop the previous player, or two will sound at once.`,
+  widget — send the whole revised pattern and ask the user to stop the
+  previous player, or two will sound at once.`,
   advanced: `# Strudel Advanced Features
 
 ## Visualization

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 // AUTO-GENERATED from package.json by scripts/sync-version.mjs — do not edit by hand.
-export const VERSION = "0.5.4";
+export const VERSION = "0.5.5";

--- a/tests/guide-executable.test.ts
+++ b/tests/guide-executable.test.ts
@@ -136,11 +136,12 @@ describe("strudel guide method names exist", () => {
    * so a method that upstream simply does not have can sit in the guide
    * forever. (`.euclidInv` was exactly that: plausible, documented, absent.)
    *
-   * The `visuals` topic is excluded: its chains are Hydra's API (.kaleid(),
+   * The `hydra` topic is excluded: its chains are Hydra's API (.kaleid(),
    * .modulateRotate(), .colorama() ...), not Strudel's, and Hydra is a WebGL
-   * runtime this suite deliberately does not bring up.
+   * runtime this suite deliberately does not bring up. (`visuals` — draw
+   * methods, presets, theme — is Strudel's own API and IS checked.)
    */
-  const CHECKED = Object.entries(STRUDEL_GUIDES).filter(([topic]) => topic !== "visuals");
+  const CHECKED = Object.entries(STRUDEL_GUIDES).filter(([topic]) => topic !== "hydra");
 
   /** Method names the guides name in order to say they do NOT exist. */
   const COUNTEREXAMPLES = new Set([

--- a/tests/prompts.test.ts
+++ b/tests/prompts.test.ts
@@ -46,7 +46,7 @@ describe("music prompts", () => {
     expect(text).toContain("play-live-pattern");
     expect(text).toContain("get-strudel-guide");
     // A pattern with no visual renders as a bare code box; point at the topic.
-    expect(text).toContain('topic "visuals"');
+    expect(text).toContain('topic "hydra"');
   });
 
   it("harmonize-melody embeds the melody and targets play-sheet-music", async () => {

--- a/tests/strudel.test.ts
+++ b/tests/strudel.test.ts
@@ -72,13 +72,14 @@ describe("get-strudel-guide handler", () => {
     }
   });
 
-  it("covers all 8 topics", () => {
-    expect(STRUDEL_GUIDE_TOPICS).toHaveLength(8);
+  it("covers all 9 topics", () => {
+    expect(STRUDEL_GUIDE_TOPICS).toHaveLength(9);
     expect(STRUDEL_GUIDE_TOPICS).toContain("visuals");
+    expect(STRUDEL_GUIDE_TOPICS).toContain("hydra");
   });
 });
 
-describe("strudel visualization guidance (v0.4.1, moved to 'visuals' in v0.5)", () => {
+describe("strudel visualization guidance (v0.4.1, 'visuals' in v0.5, split into 'visuals' + 'hydra' in v0.5.5)", () => {
   const visuals = STRUDEL_GUIDES.visuals;
 
   it("encourages visualization with concrete methods", () => {
@@ -104,7 +105,7 @@ describe("strudel visualization guidance (v0.4.1, moved to 'visuals' in v0.5)", 
   it("nudges visualization + Hydra from the play-live tool description", () => {
     expect(PLAY_LIVE_BASE_DESCRIPTION).toContain("pianoroll");
     expect(PLAY_LIVE_BASE_DESCRIPTION).toContain("initHydra");
-    expect(PLAY_LIVE_BASE_DESCRIPTION).toContain("'visuals'");
+    expect(PLAY_LIVE_BASE_DESCRIPTION).toContain("'hydra'");
   });
 
   it("advertises the visuals + theme parameters and the audio-reactive path", () => {
@@ -116,19 +117,24 @@ describe("strudel visualization guidance (v0.4.1, moved to 'visuals' in v0.5)", 
     expect((PLAY_LIVE_BASE_DESCRIPTION + PLAY_LIVE_EXT_APPS_SUFFIX).length).toBeLessThan(2048);
   });
 
-  it("says the visuals topic covers audio-reactive shaders", () => {
-    expect(GET_STRUDEL_GUIDE_DESCRIPTION).toContain("audio-reactive shaders");
+  it("says the hydra topic covers audio-reactive shaders", () => {
+    expect(GET_STRUDEL_GUIDE_DESCRIPTION).toContain("audio-reactive a.fft");
   });
 });
 
 describe("visuals guide topic", () => {
-  const text = STRUDEL_GUIDES.visuals;
+  // The shader half moved to its own topic in v0.5.5 (the combined topic was
+  // 13 KB — an agent that wanted a piano roll paid for four shader recipes).
+  // These assertions read both, so the split cannot lose a rule.
+  const text = STRUDEL_GUIDES.visuals + "\n" + STRUDEL_GUIDES.hydra;
 
   it("teaches both layers: draw methods and Hydra", () => {
-    expect(text).toContain(".pianoroll()");
-    expect(text).toContain("await initHydra()");
-    expect(text).toContain("feedStrudel");
-    expect(text).toContain("H(");
+    expect(STRUDEL_GUIDES.visuals).toContain(".pianoroll()");
+    expect(STRUDEL_GUIDES.visuals).toContain('topic "hydra"');
+    expect(STRUDEL_GUIDES.hydra).toContain("await initHydra()");
+    expect(STRUDEL_GUIDES.hydra).toContain("feedStrudel");
+    expect(STRUDEL_GUIDES.hydra).toContain("H(");
+    expect(STRUDEL_GUIDES.hydra).toContain('topic "visuals"');
   });
 
   it("still tells the agent not to reach for the microphone", () => {


### PR DESCRIPTION
Splits the 13 KB visuals topic into 'visuals' (draw methods, presets, theme, Stage) and 'hydra' (shaders, H(), a.fft, recipes, cheat-sheet). Additive — 'visuals' stays valid. All references repointed; 9 guide topics / 16 guide resources now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGyGZbzdNkP2THuJDifpZL